### PR TITLE
Add missing `params.expand` key for `getSpace`.

### DIFF
--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -129,6 +129,9 @@ export class Space {
     const config: RequestConfig = {
       url: `/api/space/${parameters.spaceKey}`,
       method: 'GET',
+      params: {
+        expand: parameters.expand,
+      },
     };
 
     return this.client.sendRequest(config, callback);


### PR DESCRIPTION
Add missing code allow us to specify a params `expand` key.

Available in doc: https://developer.atlassian.com/cloud/confluence/rest/api-group-space/#api-wiki-rest-api-space-spacekey-get