### PR TITLE
Fix missing getSpaces expand param

### DIFF
--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -41,6 +41,7 @@ export class Space {
         favouriteUserKey: parameters?.favouriteUserKey,
         start: parameters?.start,
         limit: parameters?.limit,
+        expand: parameters?.expand,
       },
     };
 


### PR DESCRIPTION
Hi,

While working with this library I got an issue with unexpanded data in response using `getSpaces`.
Expand params is not passed in `sendRequest`.

This PR should fix that.

Best regards,

Alexandre.