### PR TITLE
Add atlas_doc_format

### DIFF
--- a/src/api/models/attachment.ts
+++ b/src/api/models/attachment.ts
@@ -14,6 +14,7 @@ export interface Attachment {
     comment: string;
     mediaTypeDescription: string;
     fileId: string;
+    collectionName: string;
   };
   _expandable: {
     childTypes: string;

--- a/src/api/models/attachment.ts
+++ b/src/api/models/attachment.ts
@@ -14,7 +14,7 @@ export interface Attachment {
     comment: string;
     mediaTypeDescription: string;
     fileId: string;
-    collectionName: string;
+    collectionName?: string;
   };
   _expandable: {
     childTypes: string;

--- a/src/api/models/content.ts
+++ b/src/api/models/content.ts
@@ -31,6 +31,7 @@ export interface Content {
     storage?: ContentBody;
     editor2?: ContentBody;
     anonymous_export_view?: ContentBody;
+    atlas_doc_format?: ContentBody;
     _expandable: {
       editor?: string;
       view?: string;
@@ -39,6 +40,7 @@ export interface Content {
       storage?: string;
       editor2?: string;
       anonymous_export_view?: string;
+      atlas_doc_format?: string;
     };
   };
   restrictions?: {

--- a/src/api/models/contentCreate.ts
+++ b/src/api/models/contentCreate.ts
@@ -47,5 +47,6 @@ export interface ContentCreate {
     storage?: ContentBodyCreate;
     editor2?: ContentBodyCreate;
     anonymous_export_view?: ContentBodyCreate;
+    atlas_doc_format?: ContentBodyCreate;
   };
 }

--- a/src/api/models/contentUpdate.ts
+++ b/src/api/models/contentUpdate.ts
@@ -38,5 +38,6 @@ export interface ContentUpdate {
     storage?: ContentBodyCreateStorage;
     editor2?: ContentBodyCreate;
     anonymous_export_view?: ContentBodyCreate;
+    atlas_doc_format?: ContentBodyCreate;
   };
 }

--- a/src/server/models/content.ts
+++ b/src/server/models/content.ts
@@ -30,6 +30,7 @@ export interface Content {
     storage?: ContentBody;
     editor2?: ContentBody;
     anonymous_export_view?: ContentBody;
+    atlas_doc_format?: ContentBody;
     _expandable: {
       editor?: string;
       view?: string;
@@ -38,6 +39,7 @@ export interface Content {
       storage?: string;
       editor2?: string;
       anonymous_export_view?: string;
+      atlas_doc_format?: string;
     };
   };
   restrictions?: {


### PR DESCRIPTION
Add https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/ 
https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content/#api-wiki-rest-api-content-id-put

Adding the ADF format for APIs to read and write pages

Add `collectionName` which is required to insert images into ADF formatted pages for confluence