### PR TITLE
Initial support for ESM module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 node_modules/
 out/
+dist/
 docs/
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "license": "MIT",
   "homepage": "https://mrrefactoring.github.io/confluence.js",
   "repository": "https://github.com/MrRefactoring/confluence.js.git",
-  "main": "out/index.js",
-  "types": "out/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc --project tsconfig.esm.json",
     "prepublishOnly": "npm run build && npm run test && npm run lint",
     "test": "npm run test:unit && npm run test:e2e",
     "prettier": "prettier --write src/**/*.ts",
@@ -18,6 +19,11 @@
     "lint:fix": "npm run lint -- --fix",
     "test:unit": "ava tests/unit",
     "test:e2e": "ava --timeout=2m --fail-fast --no-worker-threads -c 1 -s tests/e2e/**/*.test.ts"
+  },
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js",
+    "default": "./dist/cjs/index.js"
   },
   "ava": {
     "extensions": [

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "ES2020",
+    "outDir": "dist/esm",
+    "moduleResolution": "node",
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "CommonJS",
-    "outDir": "out",
+    "outDir": "dist/cjs",
+    "declarationDir": "dist/types",
     "strict": true,
     "sourceMap": true,
     "declaration": true,
@@ -12,6 +13,7 @@
   "exclude": [
     "node_modules",
     "out",
+    "dist",
     "tests"
   ]
 }


### PR DESCRIPTION
Adding ESM output to compliment the CommonJS output. This will help with importing into other ESM projects. This leaves CommonJS as the default for now. Probably a major version bump due to the size of the changes. No timeline needed on this PR from my side. 

Based on https://dev.to/mbarzeev/hybrid-npm-package-through-typescript-compiler-tsc-150c 
