### PR TITLE
Refactor getBlogPostById interface and implementation params

### DIFF
--- a/src/version2/blogPost.ts
+++ b/src/version2/blogPost.ts
@@ -110,8 +110,8 @@ export class BlogPost {
       url: `/blogposts/${parameters.id}`,
       method: 'GET',
       params: {
-        'body-format': parameters['body-format'],
-        'get-draft': parameters['get-draft'],
+        'body-format': parameters.bodyFormat,
+        'get-draft': parameters.getDraft,
         version: parameters.version,
         'serialize-ids-as-strings': true,
       },

--- a/src/version2/parameters/getBlogPostById.ts
+++ b/src/version2/parameters/getBlogPostById.ts
@@ -8,9 +8,9 @@ export interface GetBlogPostById {
    * The content format types to be returned in the `body` field of the response. If available, the representation will
    * be available under a response field of the same name under the `body` field.
    */
-  'body-format'?: {};
+  bodyFormat?: {};
   /** Retrieve the draft version of this blog post. */
-  'get-draft'?: boolean;
+  getDraft?: boolean;
   /**
    * Allows you to retrieve a previously published version. Specify the previous version's number to retrieve its
    * details.


### PR DESCRIPTION
Resolved #58 

I think it is necessary to change the getBlogPostById.ts params as well. At least my delinter was getting upset when I did not do that. 