### PR TITLE
fix(getInlineCommentVersions): dashed to camelCase convention

### DIFF
--- a/src/version2/parameters/getInlineCommentVersions.ts
+++ b/src/version2/parameters/getInlineCommentVersions.ts
@@ -5,7 +5,7 @@ export interface GetInlineCommentVersions {
    * The content format types to be returned in the `body` field of the response. If available, the representation will
    * be available under a response field of the same name under the `body` field.
    */
-  'body-format'?: {};
+  'bodyFormat'?: {};
   /**
    * Used for pagination, this opaque cursor will be returned in the `next` URL in the `Link` response header. Use the
    * relative URL in the `Link` header to retrieve the `next` set of results.

--- a/src/version2/parameters/getInlineCommentVersions.ts
+++ b/src/version2/parameters/getInlineCommentVersions.ts
@@ -5,7 +5,7 @@ export interface GetInlineCommentVersions {
    * The content format types to be returned in the `body` field of the response. If available, the representation will
    * be available under a response field of the same name under the `body` field.
    */
-  'bodyFormat'?: {};
+  bodyFormat?: {};
   /**
    * Used for pagination, this opaque cursor will be returned in the `next` URL in the `Link` response header. Use the
    * relative URL in the `Link` header to retrieve the `next` set of results.

--- a/src/version2/version.ts
+++ b/src/version2/version.ts
@@ -376,7 +376,7 @@ export class Version {
       url: `/inline-comments/${parameters.id}/versions`,
       method: 'GET',
       params: {
-        'body-format': parameters['body-format'],
+        'body-format': parameters.bodyFormat,
         cursor: parameters.cursor,
         limit: parameters.limit,
         sort: parameters.sort,


### PR DESCRIPTION
Please review the PR for the below issue:
https://github.com/MrRefactoring/confluence.js/issues/82