### PR TITLE
Converted parameters in getTasks to CamelCase

### DIFF
--- a/src/version2/parameters/getTasks.ts
+++ b/src/version2/parameters/getTasks.ts
@@ -3,9 +3,9 @@ export interface GetTasks {
    * The content format types to be returned in the `body` field of the response. If available, the representation will
    * be available under a response field of the same name under the `body` field.
    */
-  'body-format'?: {};
+  bodyFormat?: {};
   /** Specifies whether to include blank tasks in the response. Defaults to `true`. */
-  'include-blank-tasks'?: boolean;
+  includeBlankTasks?: boolean;
   /** Filters on the status of the task. */
   status?: string;
   /** Filters on task ID. Multiple IDs can be specified. */
@@ -21,34 +21,34 @@ export interface GetTasks {
    * Filters on the blog post ID of the task. Multiple IDs can be specified. Note - page and blog post filters can be
    * used in conjunction.
    */
-  'blogpost-id'?: number[];
+  blogpostId?: number[];
   /** Filters on the Account ID of the user who created this task. Multiple IDs can be specified. */
-  'created-by'?: string[];
+  createdBy?: string[];
   /** Filters on the Account ID of the user to whom this task is assigned. Multiple IDs can be specified. */
-  'assigned-to'?: string[];
+  assignedTo?: string[];
   /** Filters on the Account ID of the user who completed this task. Multiple IDs can be specified. */
-  'completed-by'?: string[];
+  completedBy?: string[];
   /**
    * Filters on start of date-time range of task based on creation date (inclusive). Input is epoch time in
    * milliseconds.
    */
-  'created-at-from'?: number;
+  createdAtFrom?: number;
   /** Filters on end of date-time range of task based on creation date (inclusive). Input is epoch time in milliseconds. */
-  'created-at-to'?: number;
+  createdAtTo?: number;
   /** Filters on start of date-time range of task based on due date (inclusive). Input is epoch time in milliseconds. */
-  'due-at-from'?: number;
+  dueAtFrom?: number;
   /** Filters on end of date-time range of task based on due date (inclusive). Input is epoch time in milliseconds. */
-  'due-at-to'?: number;
+  dueAtTo?: number;
   /**
    * Filters on start of date-time range of task based on completion date (inclusive). Input is epoch time in
    * milliseconds.
    */
-  'completed-at-from'?: number;
+  completedAtFrom?: number;
   /**
    * Filters on end of date-time range of task based on completion date (inclusive). Input is epoch time in
    * milliseconds.
    */
-  'completed-at-to'?: number;
+  completedAtTo?: number;
   /**
    * Used for pagination, this opaque cursor will be returned in the `next` URL in the `Link` response header. Use the
    * relative URL in the `Link` header to retrieve the `next` set of results.

--- a/src/version2/task.ts
+++ b/src/version2/task.ts
@@ -5,7 +5,7 @@ import { Client } from '../clients';
 import { RequestConfig } from '../requestConfig';
 
 export class Task {
-  constructor(private client: Client) {}
+  constructor(private client: Client) { }
 
   /**
    * Returns all tasks. The number of results is limited by the `limit` parameter and additional results (if available)
@@ -34,22 +34,22 @@ export class Task {
       url: '/tasks',
       method: 'GET',
       params: {
-        'body-format': parameters?.['body-format'],
-        'include-blank-tasks': parameters?.['include-blank-tasks'],
+        'body-format': parameters?.bodyFormat,
+        'include-blank-tasks': parameters?.includeBlankTasks,
         status: parameters?.status,
         'task-id': parameters?.taskId,
         'space-id': parameters?.spaceId,
         'page-id': parameters?.pageId,
-        'blogpost-id': parameters?.['blogpost-id'],
-        'created-by': parameters?.['created-by'],
-        'assigned-to': parameters?.['assigned-to'],
-        'completed-by': parameters?.['completed-by'],
-        'created-at-from': parameters?.['created-at-from'],
-        'created-at-to': parameters?.['created-at-to'],
-        'due-at-from': parameters?.['due-at-from'],
-        'due-at-to': parameters?.['due-at-to'],
-        'completed-at-from': parameters?.['completed-at-from'],
-        'completed-at-to': parameters?.['completed-at-to'],
+        'blogpost-id': parameters?.blogpostId,
+        'created-by': parameters?.createdBy,
+        'assigned-to': parameters?.assignedTo,
+        'completed-by': parameters?.completedBy,
+        'created-at-from': parameters?.createdAtFrom,
+        'created-at-to': parameters?.createdAtTo,
+        'due-at-from': parameters?.dueAtFrom,
+        'due-at-to': parameters?.dueAtTo,
+        'completed-at-from': parameters?.completedAtFrom,
+        'completed-at-to': parameters?.completedAtTo,
         cursor: parameters?.cursor,
         limit: parameters?.limit,
         'serialize-ids-as-strings': true,


### PR DESCRIPTION
## Description

Fixed issue #83 

Also, it was giving errors when I converted them to `camelCase`, due to the parameter names still being `dash-cased` in [getTasks.ts](https://github.com/MrRefactoring/confluence.js/blob/feature/v2-api/src/version2/parameters/getTasks.ts). Therefore I converted those to `camelCase` as well.