### PR TITLE
Add the "Content-Type" header to the movePage api call.

### DIFF
--- a/src/api/contentChildrenAndDescendants.ts
+++ b/src/api/contentChildrenAndDescendants.ts
@@ -97,6 +97,9 @@ export class ContentChildrenAndDescendants {
     const config: RequestConfig = {
       url: `/api/content/${pageId}/move/${parameters.position}/${parameters.targetId}`,
       method: 'PUT',
+      headers: {
+	'Content-Type': 'application/json'
+      }
     };
 
     return this.client.sendRequest(config, callback);


### PR DESCRIPTION
This prevents the "Content-Type" automatically being set to "application/x-www-form-urlencoded".