### PR TITLE
Use expand parameter in getContentByTypeForSpace

### DIFF
--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -271,6 +271,7 @@ export class Space {
       method: 'GET',
       params: {
         depth: parameters.depth,
+        expand: parameters.expand,
         start: parameters.start,
         limit: parameters.limit,
       },

--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -234,6 +234,7 @@ export class Space {
       method: 'GET',
       params: {
         depth: parameters.depth,
+        expand: parameters.expand,
         start: parameters.start,
         limit: parameters.limit,
       },


### PR DESCRIPTION
Simply uses the already defined parameter https://github.com/MrRefactoring/confluence.js/blob/6c835f8973c6682912f1800a16b3caa05e104907/src/api/parameters/getContentByTypeForSpace.ts#L9

Fixes #136 