### PR TITLE
fix: getContentComments `expand` field not being used

### DIFF
--- a/src/api/contentComments.ts
+++ b/src/api/contentComments.ts
@@ -40,6 +40,7 @@ export class ContentComments {
         limit: parameters.limit,
         location: parameters.location,
         depth: parameters.depth,
+        expand: parameters.expand,
       },
     };
 


### PR DESCRIPTION
Self-explanatory. Stumbled upon this trying to analyze comments at work. Would appreciate if you release this fix asap. 