### PR TITLE
version comment

### DIFF
--- a/src/api/models/contentCreate.ts
+++ b/src/api/models/contentCreate.ts
@@ -49,4 +49,12 @@ export interface ContentCreate {
     anonymous_export_view?: ContentBodyCreate;
     atlas_doc_format?: ContentBodyCreate;
   };
+  /**
+   * The new version for the created content. 
+   * To get the current version number, use [Get content by ID](#api-content-id-get) and retrieve `version.number`.
+   */
+  version?: {    
+    /** The version comment. */
+    message?: string;
+  };
 }

--- a/src/api/models/contentUpdate.ts
+++ b/src/api/models/contentUpdate.ts
@@ -11,6 +11,8 @@ export interface ContentUpdate {
   version: {
     /** The version number. */
     number: number;
+    /** The version comment. */
+    message?: string;
   };
   /** The updated title of the content. If you are not changing this field, set this to the current `title`. */
   title: string;


### PR DESCRIPTION
### Support version comments

We want to be able to create/update pages with version comments like this:
![image](https://github.com/MrRefactoring/confluence.js/assets/6381507/902706cd-9fd1-456b-914e-174523a9a7c7)

It's also documented here:
https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/#create-a-new-page