### PR TITLE
#145: add `start` and `limit` properties for `contentChildrenAndDescendants.getContentChildren`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   - Added `key` property to `longRunningTask.getTasks`
   - Added `sitePermissionTypeFilter` property to `search.searchUser`
   - Added `alias` property to both `space.createSpace` and `space.createPrivateSpace`
+  - #145 Added `start` and `limit` properties to `contentChildrenAndDescendants.getContentChildren`. Thanks to @javierbrea for requesting this feature.
 
 ### **API Changes** 🔄
 - **Experimental methods moved**:

--- a/src/api/contentChildrenAndDescendants.ts
+++ b/src/api/contentChildrenAndDescendants.ts
@@ -65,6 +65,8 @@ export class ContentChildrenAndDescendants {
       params: {
         expand: parameters.expand,
         parentVersion: parameters.parentVersion,
+        start: parameters.start,
+        limit: parameters.limit,
       },
     };
 

--- a/src/api/parameters/getContentChildren.ts
+++ b/src/api/parameters/getContentChildren.ts
@@ -1,3 +1,5 @@
+import type { OneOrMany } from '../../interfaces';
+
 export interface GetContentChildren {
   /** The ID of the content to be queried for its children. */
   id: string;
@@ -9,7 +11,11 @@ export interface GetContentChildren {
    * - `page` returns all child pages of the content.
    * - Custom content types that are provided by apps are also supported.
    */
-  expand?: string[];
+  expand?: OneOrMany<'attachment' | 'comments' | 'page' | string>;
   /** The version of the parent content to retrieve children for. Currently, this only works for the latest version. */
   parentVersion?: number;
+  /** The starting index of the returned content children. */
+  start?: number;
+  /** The maximum number of content children to return per page. */
+  limit?: number;
 }

--- a/tests/unit/api/contentChildrenAndDescendants.test.ts
+++ b/tests/unit/api/contentChildrenAndDescendants.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContentChildrenAndDescendants } from '~/api/contentChildrenAndDescendants';
+import type { RequestConfig } from '~/requestConfig';
+
+describe('getContentChildren', () => {
+  let client: ContentChildrenAndDescendants;
+  const mockSendRequest = vi.fn();
+
+  beforeEach(() => {
+    // Create a fresh instance for each test
+    mockSendRequest.mockReset();
+    mockSendRequest.mockResolvedValue({});
+    client = new ContentChildrenAndDescendants({
+      sendRequest: mockSendRequest,
+    });
+  });
+
+  it('should use all parameters in the request config', async () => {
+    // Arrange
+    const testParams = {
+      id: '12345',
+      expand: ['body.view', 'version'],
+      parentVersion: 2,
+      start: 10,
+      limit: 25,
+    };
+
+    // Mock the successful response
+    mockSendRequest.mockResolvedValue({
+      page: [],
+      comment: [],
+      attachment: [],
+    });
+
+    // Act
+    await client.getContentChildren(testParams);
+
+    // Assert
+    expect(mockSendRequest).toHaveBeenCalledTimes(1);
+
+    const calledConfig: RequestConfig = mockSendRequest.mock.calls[0][0];
+
+    // Verify URL construction with content ID
+    expect(calledConfig.url).toBe(`/api/content/${testParams.id}/child`);
+    expect(calledConfig.method).toBe('GET');
+
+    // Verify all query parameters
+    expect(calledConfig.params).toEqual({
+      expand: testParams.expand,
+      parentVersion: testParams.parentVersion,
+      start: testParams.start,
+      limit: testParams.limit,
+    });
+  });
+});


### PR DESCRIPTION
Closing #145 