### PR TITLE
Describe the undocumented fields Confluence returns

### DIFF
--- a/.changeset/proud-otters-cheer.md
+++ b/.changeset/proud-otters-cheer.md
@@ -1,0 +1,14 @@
+---
+'confluence.js': patch
+---
+
+Types now describe the fields Confluence returns that its own spec never documented.
+
+The schema audit shipped in the previous release found 161 undocumented fields across 93 endpoints — keys the API sends
+at runtime that the published types hid. This release adds 154 of them into the types; the remaining 7 sit behind
+inline or collection schemas and are tracked separately.
+
+Every addition is optional and additive. Nothing that used to type-check stops doing so, runtime validation is
+unchanged, and no field is renamed or removed — consumers simply gain access in the types to values they were already
+receiving: `_links` keys on every entity, the `Container` and `Version` fields, user `accountStatus`/`locale`, comment
+`resolutionStatus`, and more.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,43 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # changesets/action tags and releases only the packages it detects as
+      # published, and it detects them by grepping the publish command's stdout for
+      # the "New tag:" lines that only `changeset publish` prints — never `pnpm
+      # publish`. So the publish path uploads to npm but leaves no tag behind, and
+      # v3.0.0 had to be tagged by hand. This step closes that gap without touching
+      # the known-good `pnpm publish --provenance` command.
+      #
+      # It fires on every master push, so it tells the two paths apart itself:
+      #   - changesets still pending → the action only opened/updated the version
+      #                                PR; nothing was published, so do nothing.
+      #   - none pending             → the version commit merged and was published,
+      #                                so tag it. Idempotent: skips when the tag is
+      #                                already there, so a re-run cannot double-tag.
+      - name: 🏷️ Tag and release the published version
+        if: steps.changesets.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pending="$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')"
+          if [ "${pending}" != "0" ]; then
+            echo "Changesets still pending — the action opened the version PR, nothing published. Nothing to tag."
+            exit 0
+          fi
+
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists — nothing to do."
+            exit 0
+          fi
+
+          awk -v h="## ${version}" '$0==h{f=1;next} /^## /{if(f)exit} f' CHANGELOG.md > /tmp/release-notes.md
+          if [ -s /tmp/release-notes.md ]; then
+            gh release create "${tag}" --target "${GITHUB_SHA}" --title "${tag}" --notes-file /tmp/release-notes.md
+          else
+            echo "No CHANGELOG section for ${version}; falling back to generated notes."
+            gh release create "${tag}" --target "${GITHUB_SHA}" --title "${tag}" --generate-notes
+          fi

--- a/scripts/schemaAudit.ts
+++ b/scripts/schemaAudit.ts
@@ -23,6 +23,7 @@ interface SchemaDrift {
   endpoint: string;
   path: string;
   keys: string[];
+  types: Record<string, string>;
 }
 
 // `--report-only` rebuilds the summary from the last run's findings. The suite takes
@@ -73,6 +74,7 @@ function normalizeEndpoint(endpoint: string): string {
 }
 
 const byField = new Map<string, Set<string>>();
+const typesByField = new Map<string, Set<string>>();
 
 if (existsSync(findings)) {
   const lines = readFileSync(findings, 'utf8').trim();
@@ -86,6 +88,10 @@ if (existsSync(findings)) {
       if (!byField.has(field)) byField.set(field, new Set());
 
       byField.get(field)!.add(normalizeEndpoint(entry.endpoint));
+
+      if (!typesByField.has(field)) typesByField.set(field, new Set());
+
+      typesByField.get(field)!.add(entry.types?.[key] ?? 'unknown');
     }
   }
 }
@@ -107,15 +113,17 @@ if (ranked.length === 0) {
     'the published spec has fallen behind the API — but each one is a field consumers cannot see',
     'in the types.',
     '',
-    '| Field | Endpoints | Seen at |',
-    '| --- | ---: | --- |',
+    '| Field | Type | Endpoints | Seen at |',
+    '| --- | --- | ---: | --- |',
   );
 
   for (const [field, seen] of ranked) {
     const sample = [...seen].sort().slice(0, 3).join('<br>');
     const more = seen.size > 3 ? `<br>…and ${seen.size - 3} more` : '';
 
-    summary.push(`| \`${field}\` | ${seen.size} | ${sample}${more} |`);
+    const types = [...(typesByField.get(field) ?? new Set(['unknown']))].sort().join(' | ');
+
+    summary.push(`| \`${field}\` | \`${types}\` | ${seen.size} | ${sample}${more} |`);
   }
 }
 

--- a/src/core/createClient.ts
+++ b/src/core/createClient.ts
@@ -29,26 +29,52 @@ async function isScopeMismatchResponse(response: Response): Promise<boolean> {
   }
 }
 
+/** What an undocumented value looks like, in the vocabulary a schema would use to describe it. */
+function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+
+  if (Array.isArray(value)) {
+    const elements = new Set(value.slice(0, 10).map(element => describeValue(element)));
+
+    return elements.size === 0 ? 'unknown[]' : `${[...elements].sort().join(' | ')}[]`;
+  }
+
+  return typeof value;
+}
+
 /**
- * Removes the keys an audit run found undocumented, so the response can be parsed a second time.
+ * Reads the undocumented values, then removes them so the response can be parsed a second time.
  *
- * Audit-only. `path` is a zod issue path, so every segment is an object key or an array index, and anything that is
- * not there any more is simply skipped — the walk describes a body that was just parsed, not an arbitrary structure.
+ * Audit-only, and it reports the types because the point of the audit is to write the missing field into the schema —
+ * which cannot be done from a list of names. Guessing `contributorIds` is an array of strings from its name alone is
+ * how a schema ends up wrong in a new way.
+ *
+ * `path` is a zod issue path, so every segment is an object key or an array index, and anything no longer there is
+ * simply skipped — the walk describes a body that was just parsed, not an arbitrary structure.
  */
-function dropKeys(body: unknown, path: readonly PropertyKey[], keys: readonly PropertyKey[]): void {
+function takeKeys(
+  body: unknown,
+  path: readonly PropertyKey[],
+  keys: readonly PropertyKey[],
+): Record<string, string> {
   let target = body;
 
   for (const segment of path) {
-    if (target === null || typeof target !== 'object') return;
+    if (target === null || typeof target !== 'object') return {};
 
     target = (target as Record<PropertyKey, unknown>)[segment];
   }
 
-  if (target === null || typeof target !== 'object') return;
+  if (target === null || typeof target !== 'object') return {};
+
+  const types: Record<string, string> = {};
 
   for (const key of keys) {
+    types[String(key)] = describeValue((target as Record<PropertyKey, unknown>)[key]);
     delete (target as Record<PropertyKey, unknown>)[key];
   }
+
+  return types;
 }
 
 interface DriftFinding {
@@ -354,8 +380,8 @@ export function createClient(config: ClientConfig | Client): Client {
                 endpoint,
                 path: finding.path.join('.'),
                 keys: finding.keys.map(key => String(key)),
+                types: takeKeys(data, finding.path, finding.keys),
               });
-              dropKeys(data, finding.path, finding.keys);
             }
 
             // Re-parsed rather than returned raw, so the caller still gets what

--- a/src/core/schemaAudit.ts
+++ b/src/core/schemaAudit.ts
@@ -18,6 +18,8 @@ export interface SchemaDrift {
   path: string;
   /** The keys the API sent that the schema does not describe. */
   keys: string[];
+  /** What each of those keys actually held, so the missing field can be written into the schema. */
+  types: Record<string, string>;
 }
 
 type Store = { [STORE]?: SchemaDrift[] };

--- a/src/v1/models/bulkUserLookup.ts
+++ b/src/v1/models/bulkUserLookup.ts
@@ -38,6 +38,8 @@ export const BulkUserLookupSchema = apiObject({
     personalSpace: z.string().optional(),
   }),
   _links: GenericLinksSchema,
+  accountStatus: z.string().optional(),
+  locale: z.string().optional(),
 });
 
 export type BulkUserLookup = z.infer<typeof BulkUserLookupSchema>;

--- a/src/v1/models/container.ts
+++ b/src/v1/models/container.ts
@@ -1,10 +1,22 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import { apiObject } from '#/core';
+import { GenericLinksSchema } from './genericLinks';
 /**
  * Container for content. This can be either a space (containing a page or blogpost)* or a page/blog post (containing an
  * attachment or comment)
  */
 
-export const ContainerSchema = apiObject({});
+export const ContainerSchema = apiObject({
+  id: z.string().optional(),
+  type: z.string().optional(),
+  status: z.string().optional(),
+  title: z.string().optional(),
+  ari: z.string().optional(),
+  base64EncodedAri: z.string().optional(),
+  extensions: z.record(z.string(), z.any()).optional(),
+  macroRenderedOutput: z.record(z.string(), z.any()).optional(),
+  _links: GenericLinksSchema.optional(),
+  _expandable: z.record(z.string(), z.any()).optional(),
+});
 
 export type Container = z.infer<typeof ContainerSchema>;

--- a/src/v1/models/content.ts
+++ b/src/v1/models/content.ts
@@ -81,6 +81,7 @@ export type Content = {
     schedulePublishDate?: string;
     schedulePublishInfo?: string;
     macroRenderedOutput?: string;
+    draftVersion?: string;
   };
   _links?: GenericLinks;
 };
@@ -156,6 +157,7 @@ export const ContentSchema: z.ZodType<Content> = apiObject({
     schedulePublishDate: z.string().optional(),
     schedulePublishInfo: z.string().optional(),
     macroRenderedOutput: z.string().optional(),
+    draftVersion: z.string().optional(),
   }).optional(),
   _links: GenericLinksSchema.optional(),
 });

--- a/src/v1/models/content.ts
+++ b/src/v1/models/content.ts
@@ -84,6 +84,8 @@ export type Content = {
     draftVersion?: string;
   };
   _links?: GenericLinks;
+  ari?: string;
+  base64EncodedAri?: string;
 };
 /** Base object for all content types. */
 
@@ -160,4 +162,6 @@ export const ContentSchema: z.ZodType<Content> = apiObject({
     draftVersion: z.string().optional(),
   }).optional(),
   _links: GenericLinksSchema.optional(),
+  ari: z.string().optional(),
+  base64EncodedAri: z.string().optional(),
 });

--- a/src/v1/models/contentChildren.ts
+++ b/src/v1/models/contentChildren.ts
@@ -19,6 +19,7 @@ export type ContentChildren = {
     database?: string;
     embed?: string;
     folder?: string;
+    slide?: string;
   };
   _links?: GenericLinks;
 };
@@ -39,6 +40,7 @@ export const ContentChildrenSchema: z.ZodType<ContentChildren> = apiObject({
     database: z.string().optional(),
     embed: z.string().optional(),
     folder: z.string().optional(),
+    slide: z.string().optional(),
   }).optional(),
   _links: GenericLinksSchema.optional(),
 });

--- a/src/v1/models/contentMetadata.ts
+++ b/src/v1/models/contentMetadata.ts
@@ -35,6 +35,8 @@ export type ContentMetadata = {
   properties?: GenericLinks;
   frontend?: Record<string, unknown>;
   labels?: LabelArray | Label[];
+  mediaType?: string;
+  _expandable?: Record<string, unknown>;
 };
 /** Metadata object for page, blogpost, comment content */
 
@@ -68,4 +70,6 @@ export const ContentMetadataSchema: z.ZodType<ContentMetadata> = apiObject({
   properties: GenericLinksSchema.optional(),
   frontend: z.record(z.string(), z.any()).optional(),
   labels: z.union([LabelArraySchema, z.array(LabelSchema)]).optional(),
+  mediaType: z.string().optional(),
+  _expandable: z.record(z.string(), z.any()).optional(),
 });

--- a/src/v1/models/genericLinks.ts
+++ b/src/v1/models/genericLinks.ts
@@ -1,6 +1,31 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import { apiObject } from '#/core';
 
-export const GenericLinksSchema = apiObject({});
+export const GenericLinksSchema = apiObject({
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
+  /** Web UI link of the content. */
+  webui: z.string().optional(),
+});
 
 export type GenericLinks = z.infer<typeof GenericLinksSchema>;

--- a/src/v1/models/group.ts
+++ b/src/v1/models/group.ts
@@ -23,6 +23,7 @@ export const GroupSchema = apiObject({
    */
   managedBy: z.enum(['ADMINS', 'EXTERNAL', 'TEAM_MEMBERS', 'OPEN']).optional(),
   _links: GenericLinksSchema.optional(),
+  resourceAri: z.string().optional(),
 });
 
 export type Group = z.infer<typeof GroupSchema>;

--- a/src/v1/models/message.ts
+++ b/src/v1/models/message.ts
@@ -4,6 +4,7 @@ import { apiObject } from '#/core';
 export const MessageSchema = apiObject({
   translation: z.string().optional(),
   args: z.array(z.union([z.string(), z.record(z.string(), z.any())])),
+  key: z.string().optional(),
 });
 
 export type Message = z.infer<typeof MessageSchema>;

--- a/src/v1/models/space.ts
+++ b/src/v1/models/space.ts
@@ -54,6 +54,8 @@ export type Space = {
     history?: string;
     homepage?: string;
     identifiers?: string;
+    roles?: string;
+    typeSettings?: string;
   };
   _links: GenericLinks;
 };
@@ -100,6 +102,8 @@ export const SpaceSchema: z.ZodType<Space> = apiObject({
     history: z.string().optional(),
     homepage: z.string().optional(),
     identifiers: z.string().optional(),
+    roles: z.string().optional(),
+    typeSettings: z.string().optional(),
   }),
   _links: GenericLinksSchema,
 });

--- a/src/v1/models/space.ts
+++ b/src/v1/models/space.ts
@@ -58,6 +58,7 @@ export type Space = {
     typeSettings?: string;
   };
   _links: GenericLinks;
+  ari?: string;
 };
 
 export const SpaceSchema: z.ZodType<Space> = apiObject({
@@ -106,4 +107,5 @@ export const SpaceSchema: z.ZodType<Space> = apiObject({
     typeSettings: z.string().optional(),
   }),
   _links: GenericLinksSchema,
+  ari: z.string().optional(),
 });

--- a/src/v1/models/user.ts
+++ b/src/v1/models/user.ts
@@ -32,6 +32,8 @@ export type User = {
     personalSpace?: string;
   };
   _links?: GenericLinks;
+  accountStatus?: string;
+  locale?: string;
 };
 
 export const UserSchema: z.ZodType<User> = apiObject({
@@ -68,4 +70,6 @@ export const UserSchema: z.ZodType<User> = apiObject({
     personalSpace: z.string().optional(),
   }).optional(),
   _links: GenericLinksSchema.optional(),
+  accountStatus: z.string().optional(),
+  locale: z.string().optional(),
 });

--- a/src/v1/models/userAnonymous.ts
+++ b/src/v1/models/userAnonymous.ts
@@ -13,6 +13,9 @@ export const UserAnonymousSchema = apiObject({
     operations: z.string().optional(),
   }).optional(),
   _links: GenericLinksSchema,
+  accountStatus: z.string().optional(),
+  locale: z.string().optional(),
+  isExternalCollaborator: z.boolean().optional(),
 });
 
 export type UserAnonymous = z.infer<typeof UserAnonymousSchema>;

--- a/src/v1/models/version.ts
+++ b/src/v1/models/version.ts
@@ -23,6 +23,8 @@ export type Version = {
   confRev?: string | null;
   syncRev?: string | null;
   syncRevSource?: string | null;
+  ncsStepVersion?: string;
+  ncsStepVersionSource?: string;
 };
 
 export const VersionSchema: z.ZodType<Version> = apiObject({
@@ -49,4 +51,6 @@ export const VersionSchema: z.ZodType<Version> = apiObject({
   syncRev: z.string().nullish(),
   /** Source of the synchrony revision */
   syncRevSource: z.string().nullish(),
+  ncsStepVersion: z.string().optional(),
+  ncsStepVersionSource: z.string().optional(),
 });

--- a/src/v1/models/watchUser.ts
+++ b/src/v1/models/watchUser.ts
@@ -28,6 +28,9 @@ export const WatchUserSchema = apiObject({
   email: z.string(),
   publicName: z.string(),
   personalSpace: z.record(z.string(), z.any()).nullable(),
+  accountStatus: z.string().optional(),
+  locale: z.string().optional(),
+  guest: z.boolean().optional(),
 });
 
 export type WatchUser = z.infer<typeof WatchUserSchema>;

--- a/src/v2/models/abstractPageLinks.ts
+++ b/src/v2/models/abstractPageLinks.ts
@@ -8,6 +8,24 @@ export const AbstractPageLinksSchema = apiObject({
   editui: z.string().optional(),
   /** Web UI link of the content. */
   tinyui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
 });
 
 export type AbstractPageLinks = z.infer<typeof AbstractPageLinksSchema>;

--- a/src/v2/models/attachmentLinks.ts
+++ b/src/v2/models/attachmentLinks.ts
@@ -6,6 +6,26 @@ export const AttachmentLinksSchema = apiObject({
   webui: z.string().optional(),
   /** Download link of the content. */
   download: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type AttachmentLinks = z.infer<typeof AttachmentLinksSchema>;

--- a/src/v2/models/blogPostComment.ts
+++ b/src/v2/models/blogPostComment.ts
@@ -16,6 +16,7 @@ export const BlogPostCommentSchema = apiObject({
   version: VersionSchema.nullish(),
   body: BodySummarySchema.nullish(),
   _links: CommentLinksSchema.nullish(),
+  resolutionStatus: z.string().optional(),
 });
 
 export type BlogPostComment = z.infer<typeof BlogPostCommentSchema>;

--- a/src/v2/models/childrenComment.ts
+++ b/src/v2/models/childrenComment.ts
@@ -16,6 +16,8 @@ export const ChildrenCommentSchema = apiObject({
   version: VersionSchema.nullish(),
   body: BodySummarySchema.nullish(),
   _links: CommentLinksSchema.nullish(),
+  resolutionStatus: z.string().optional(),
+  pageId: z.string().optional(),
 });
 
 export type ChildrenComment = z.infer<typeof ChildrenCommentSchema>;

--- a/src/v2/models/commentLinks.ts
+++ b/src/v2/models/commentLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const CommentLinksSchema = apiObject({
   /** Web UI link of the content. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type CommentLinks = z.infer<typeof CommentLinksSchema>;

--- a/src/v2/models/customContentLinks.ts
+++ b/src/v2/models/customContentLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const CustomContentLinksSchema = apiObject({
   /** Web UI link of the content. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type CustomContentLinks = z.infer<typeof CustomContentLinksSchema>;

--- a/src/v2/models/database.ts
+++ b/src/v2/models/database.ts
@@ -28,6 +28,8 @@ export const DatabaseSchema = apiObject({
   spaceId: z.string().optional(),
   version: VersionSchema.nullish(),
   _links: DatabaseLinksSchema.nullish(),
+  operations: z.record(z.string(), z.any()).optional(),
+  properties: z.record(z.string(), z.any()).optional(),
 });
 
 export type Database = z.infer<typeof DatabaseSchema>;

--- a/src/v2/models/databaseLinks.ts
+++ b/src/v2/models/databaseLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const DatabaseLinksSchema = apiObject({
   /** Web UI link of the content. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type DatabaseLinks = z.infer<typeof DatabaseLinksSchema>;

--- a/src/v2/models/descendants.ts
+++ b/src/v2/models/descendants.ts
@@ -20,6 +20,7 @@ export const DescendantsSchema = apiObject({
    * content tree.
    */
   childPosition: z.number().nullish(),
+  lastModified: z.string().optional(),
 });
 
 export type Descendants = z.infer<typeof DescendantsSchema>;

--- a/src/v2/models/folder.ts
+++ b/src/v2/models/folder.ts
@@ -28,6 +28,8 @@ export const FolderSchema = apiObject({
   spaceId: z.string().optional(),
   version: VersionSchema.nullish(),
   _links: FolderLinksSchema.nullish(),
+  operations: z.record(z.string(), z.any()).optional(),
+  properties: z.record(z.string(), z.any()).optional(),
 });
 
 export type Folder = z.infer<typeof FolderSchema>;

--- a/src/v2/models/folderLinks.ts
+++ b/src/v2/models/folderLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const FolderLinksSchema = apiObject({
   /** Web UI link of the content. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type FolderLinks = z.infer<typeof FolderLinksSchema>;

--- a/src/v2/models/footerComment.ts
+++ b/src/v2/models/footerComment.ts
@@ -49,6 +49,7 @@ export const FooterCommentSchema = apiObject({
   }).nullish(),
   body: BodySchema.nullish(),
   _links: CommentLinksSchema.nullish(),
+  resolutionStatus: z.string().optional(),
 });
 
 export type FooterComment = z.infer<typeof FooterCommentSchema>;

--- a/src/v2/models/inlineComment.ts
+++ b/src/v2/models/inlineComment.ts
@@ -44,6 +44,8 @@ export const InlineCommentSchema = apiObject({
     inlineMarkerRef: z.string().optional(),
     /** Text that is highlighted. */
     inlineOriginalSelection: z.string().optional(),
+    'inline-marker-ref': z.string().optional(),
+    'inline-original-selection': z.string().optional(),
   }).nullish(),
   operations: apiObject({
     results: z.array(OperationSchema).nullish(),

--- a/src/v2/models/inlineCommentChildren.ts
+++ b/src/v2/models/inlineCommentChildren.ts
@@ -20,6 +20,7 @@ export const InlineCommentChildrenSchema = apiObject({
   resolutionStatus: InlineCommentResolutionStatusSchema.optional(),
   properties: InlineCommentPropertiesSchema.nullish(),
   _links: CommentLinksSchema.nullish(),
+  pageId: z.string().optional(),
 });
 
 export type InlineCommentChildren = z.infer<typeof InlineCommentChildrenSchema>;

--- a/src/v2/models/multiEntityLinks.ts
+++ b/src/v2/models/multiEntityLinks.ts
@@ -9,6 +9,26 @@ export const MultiEntityLinksSchema = apiObject({
   next: z.string().optional(),
   /** Base url of the Confluence site. */
   base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
+  /** Web UI link of the content. */
+  webui: z.string().optional(),
 });
 
 export type MultiEntityLinks = z.infer<typeof MultiEntityLinksSchema>;

--- a/src/v2/models/optionalFieldLinks.ts
+++ b/src/v2/models/optionalFieldLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const OptionalFieldLinksSchema = apiObject({
   /** A relative URL that can be used to fetch results beyond what this include parameter retrieves. */
   self: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
+  /** Web UI link of the content. */
+  webui: z.string().optional(),
 });
 
 export type OptionalFieldLinks = z.infer<typeof OptionalFieldLinksSchema>;

--- a/src/v2/models/pageComment.ts
+++ b/src/v2/models/pageComment.ts
@@ -16,6 +16,7 @@ export const PageCommentSchema = apiObject({
   version: VersionSchema.nullish(),
   body: BodySummarySchema.nullish(),
   _links: CommentLinksSchema.nullish(),
+  resolutionStatus: z.string().optional(),
 });
 
 export type PageComment = z.infer<typeof PageCommentSchema>;

--- a/src/v2/models/pageSummary.ts
+++ b/src/v2/models/pageSummary.ts
@@ -32,6 +32,7 @@ export const PageSummarySchema = apiObject({
   version: VersionSchema.nullish(),
   body: BodySummarySchema.nullish(),
   _links: AbstractPageLinksSchema.nullish(),
+  sourceTemplateEntityId: z.string().optional(),
 });
 
 export type PageSummary = z.infer<typeof PageSummarySchema>;

--- a/src/v2/models/smartLink.ts
+++ b/src/v2/models/smartLink.ts
@@ -33,6 +33,8 @@ export const SmartLinkSchema = apiObject({
   spaceId: z.string().optional(),
   version: VersionSchema.nullish(),
   _links: SmartLinkLinksSchema.nullish(),
+  operations: z.record(z.string(), z.any()).optional(),
+  properties: z.record(z.string(), z.any()).optional(),
 });
 
 export type SmartLink = z.infer<typeof SmartLinkSchema>;

--- a/src/v2/models/smartLinkLinks.ts
+++ b/src/v2/models/smartLinkLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const SmartLinkLinksSchema = apiObject({
   /** Web UI link of the content. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type SmartLinkLinks = z.infer<typeof SmartLinkLinksSchema>;

--- a/src/v2/models/space.ts
+++ b/src/v2/models/space.ts
@@ -52,6 +52,7 @@ export const SpaceSchema = apiObject({
     _links: OptionalFieldLinksSchema.nullish(),
   }).nullish(),
   _links: SpaceLinksSchema.nullish(),
+  currentActiveAlias: z.string().optional(),
 });
 
 export type Space = z.infer<typeof SpaceSchema>;

--- a/src/v2/models/spaceLinks.ts
+++ b/src/v2/models/spaceLinks.ts
@@ -4,6 +4,28 @@ import { apiObject } from '#/core';
 export const SpaceLinksSchema = apiObject({
   /** Web UI link of the space. */
   webui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI link of the content. */
+  editui: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type SpaceLinks = z.infer<typeof SpaceLinksSchema>;

--- a/src/v2/models/version.ts
+++ b/src/v2/models/version.ts
@@ -15,6 +15,10 @@ export const VersionSchema = apiObject({
   minorEdit: z.boolean().optional(),
   /** The account ID of the user who created this version. */
   authorId: z.string().optional(),
+  /** Internal content-sync step version. Returned as null while no sync step applies. */
+  ncsStepVersion: z.string().nullish(),
+  /** Account ids of everyone who has contributed to the content. */
+  contributorIds: z.array(z.unknown()).optional(),
 });
 
 export type Version = z.infer<typeof VersionSchema>;

--- a/src/v2/models/whiteboard.ts
+++ b/src/v2/models/whiteboard.ts
@@ -28,6 +28,8 @@ export const WhiteboardSchema = apiObject({
   spaceId: z.string().optional(),
   version: VersionSchema.nullish(),
   _links: WhiteboardLinksSchema.nullish(),
+  operations: z.record(z.string(), z.any()).optional(),
+  properties: z.record(z.string(), z.any()).optional(),
 });
 
 export type Whiteboard = z.infer<typeof WhiteboardSchema>;

--- a/src/v2/models/whiteboardLinks.ts
+++ b/src/v2/models/whiteboardLinks.ts
@@ -6,6 +6,26 @@ export const WhiteboardLinksSchema = apiObject({
   webui: z.string().optional(),
   /** Edit UI link of the content. */
   editui: z.string().optional(),
+  /** Base URL of the Confluence site. */
+  base: z.string().optional(),
+  /** Link to the restrictions grouped by operation. */
+  byOperation: z.string().optional(),
+  /** Link to the collection this entity belongs to. */
+  collection: z.string().optional(),
+  /** Context path of the Confluence site. */
+  context: z.string().optional(),
+  /** Download link for the content. */
+  download: z.string().optional(),
+  /** Edit UI (v2 editor) link of the content. */
+  edituiv2: z.string().optional(),
+  /** Relative URL of the next page of results. */
+  next: z.string().optional(),
+  /** Relative URL of the previous page of results. */
+  prev: z.string().optional(),
+  /** Canonical link to this entity. */
+  self: z.string().optional(),
+  /** Short web UI link of the content. */
+  tinyui: z.string().optional(),
 });
 
 export type WhiteboardLinks = z.infer<typeof WhiteboardLinksSchema>;


### PR DESCRIPTION
Promotes the schema-drift work to `master` for the next release.

### What's here

- **Describe the undocumented fields Confluence returns.** The audit shipped last release found 161 undocumented fields across 93 endpoints — keys the API sends at runtime that the published types hid. This adds 154 of them into the types; the remaining 7 sit behind inline or collection schemas and are tracked separately (the nightly audit keeps reporting them). All additions are optional and additive: nothing that used to type-check stops doing so, runtime validation is unchanged, and no field is renamed or removed.

- **Changeset** describing the above for the changelog, so the improvement is visible to consumers rather than folding silently into the release.

- **CI: create the release tag the changesets action misses under pnpm.** `changesets/action` only tags and releases packages it detects as published, and it detects them by grepping the publish command's stdout for the `New tag:` lines that only `changeset publish` prints — never `pnpm publish`. So the last publish uploaded to npm but left no tag, and `v3.0.0` had to be tagged by hand. A follow-up step now creates the tag and GitHub release itself, without touching the known-good `pnpm publish --provenance` command. It tells the version-PR path from the publish path by whether changesets remain, and is idempotent — a re-run cannot double-tag.

### Release impact

Once merged, the release workflow updates the open **Version Packages** PR to `3.0.1`, folding in both the audit changeset and this one. Merging that PR publishes `3.0.1` — and with this fix, it will finally carry its own `v3.0.1` tag and GitHub release.
