### PR TITLE
Fix the nullable currentActiveAlias that broke the schema audit; type getRestrictionsByOperation

### DIFF
--- a/.changeset/nullable-current-active-alias.md
+++ b/.changeset/nullable-current-active-alias.md
@@ -1,0 +1,13 @@
+---
+'confluence.js': patch
+---
+
+`currentActiveAlias` is nullable, as the API returns it.
+
+The v2 spec declares the field as a plain string on both the space entity and its collection representation, but
+Confluence answers with `null` for any space that has no alias. Strict response validation rejected that, so
+`getSpaces` threw a `SchemaMismatchError` on the first aliasless space in the page, and `getSpaceById` would have
+done the same. The field is now `string | null | undefined` on `Space` and `SpaceSummary`.
+
+Existing code is unaffected: the field was already optional, so any narrowing that handled `undefined` handles
+`null` too.

--- a/.changeset/typed-get-restrictions-by-operation.md
+++ b/.changeset/typed-get-restrictions-by-operation.md
@@ -1,0 +1,17 @@
+---
+'confluence.js': minor
+---
+
+`getRestrictionsByOperation` returns a typed result instead of `unknown`.
+
+The v1 endpoint generated as `Promise<unknown>`, so its payload reached callers untyped and unvalidated. It now
+resolves to a `GetRestrictionsByOperation` and is validated like every other endpoint's response.
+
+The published spec describes this endpoint incorrectly — an open map whose values wrap a restriction in an
+`operationType`/`_links` envelope. No such envelope exists: Confluence answers with the restriction itself under each
+operation name it restricts, `read` and `update`, alongside a sibling `_links` for the response as a whole. The model
+describes what the endpoint actually returns, so `read` and `update` are typed `ContentRestriction` and nothing is
+left undescribed.
+
+Callers that treated the result as `unknown` and narrowed it themselves keep working. Code that relied on the absence
+of validation may now surface a `SchemaMismatchError` where the response does not match the model.

--- a/src/core/apiObject.ts
+++ b/src/core/apiObject.ts
@@ -7,11 +7,11 @@ import { isSchemaAuditEnabled } from './schemaAudit.js';
  * Loose by default: keys the API sends but the spec does not document pass straight through, so a field added upstream
  * never breaks a consumer between releases.
  *
- * Under `AUDIT_SCHEMAS=true` it builds strict objects instead, which is how the audit run learns *where* an
- * undocumented key sits — zod reports `unrecognized_keys` with a path, and nothing else in the pipeline knows the
- * shape well enough to say. Those failures do not reach the caller: `createClient` records them and hands back the
- * response anyway, so one stale schema cannot cut the audit short. Loose validation cannot report drift at all, since
- * accepting anything extra is precisely what it is for.
+ * Under `AUDIT_SCHEMAS=true` it builds strict objects instead, which is how the audit run learns _where_ an
+ * undocumented key sits — zod reports `unrecognized_keys` with a path, and nothing else in the pipeline knows the shape
+ * well enough to say. Those failures do not reach the caller: `createClient` records them and hands back the response
+ * anyway, so one stale schema cannot cut the audit short. Loose validation cannot report drift at all, since accepting
+ * anything extra is precisely what it is for.
  *
  * The declared return type stays the loose one in both modes, deliberately. The switch is read at runtime, so the
  * compiler cannot follow it, and the published declarations must not shift with an environment variable.

--- a/src/core/bodyToFetchBody.ts
+++ b/src/core/bodyToFetchBody.ts
@@ -7,8 +7,8 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
 /**
  * Whether the body carries its own encoding and must be handed to `fetch` untouched.
  *
- * A bare string is deliberately *not* one of these. These are JSON APIs, and the endpoints that take a lone string —
- * an account id, a preference value — want it as a JSON string, quoted, under `application/json`. Treating it as a
+ * A bare string is deliberately _not_ one of these. These are JSON APIs, and the endpoints that take a lone string — an
+ * account id, a preference value — want it as a JSON string, quoted, under `application/json`. Treating it as a
  * pre-encoded payload shipped it raw as `text/plain` and made those endpoints unreachable. Attachment content never
  * arrives here as a string: the multipart builder normalizes it into `FormData` or a stream first.
  */
@@ -43,10 +43,10 @@ export function bodyToFetchBody(body: unknown): BodyInit | AsyncIterable<unknown
 /**
  * Whether to declare `application/json` for this request.
  *
- * Sent even when there is no body, for any method that could carry one. Some endpoints reject a bodyless `DELETE`
- * with 415 unless the header is present — Jira's remote-link deletes do — and a `Content-Type` on an empty request is
- * inert everywhere else. Binary and multipart bodies are excluded because they bring their own type, and `fetch` has
- * to be left to set the multipart boundary itself.
+ * Sent even when there is no body, for any method that could carry one. Some endpoints reject a bodyless `DELETE` with
+ * 415 unless the header is present — Jira's remote-link deletes do — and a `Content-Type` on an empty request is inert
+ * everywhere else. Binary and multipart bodies are excluded because they bring their own type, and `fetch` has to be
+ * left to set the multipart boundary itself.
  */
 export function shouldSetJsonContentType(body: unknown, method?: string): boolean {
   if (isBinaryBody(body)) return false;

--- a/src/core/createClient.ts
+++ b/src/core/createClient.ts
@@ -52,11 +52,7 @@ function describeValue(value: unknown): string {
  * `path` is a zod issue path, so every segment is an object key or an array index, and anything no longer there is
  * simply skipped — the walk describes a body that was just parsed, not an arbitrary structure.
  */
-function takeKeys(
-  body: unknown,
-  path: readonly PropertyKey[],
-  keys: readonly PropertyKey[],
-): Record<string, string> {
+function takeKeys(body: unknown, path: readonly PropertyKey[], keys: readonly PropertyKey[]): Record<string, string> {
   let target = body;
 
   for (const segment of path) {
@@ -85,7 +81,7 @@ interface DriftFinding {
 /**
  * Reads a validation failure as pure schema drift, or decides it is not.
  *
- * Audit-only. Returns the undocumented keys when *every* complaint is one, and `undefined` the moment anything else
+ * Audit-only. Returns the undocumented keys when _every_ complaint is one, and `undefined` the moment anything else
  * appears — a missing field or a changed type is real breakage, and the audit must not quietly absorb it.
  *
  * Unions need the recursion. Zod reports each branch it tried, and branches that failed for their own reasons are

--- a/src/core/errors/apiError.ts
+++ b/src/core/errors/apiError.ts
@@ -58,13 +58,13 @@ export class AuthError extends ApiError {
  * 401 with `Unauthorized; scope does not match` — the token is valid, but the app never asked for a scope this endpoint
  * needs.
  *
- * A subclass of {@link AuthError} because it is still a 401, but worth its own type: refreshing the token cannot fix
- * it, so the client does not try. The app needs the scope added in the developer console and the user has to consent
+ * A subclass of {@link AuthError} because it is still a 401, but worth its own type: refreshing the token cannot fix it,
+ * so the client does not try. The app needs the scope added in the developer console and the user has to consent
  * again.
  *
- * Under 3LO this is also how the two API versions bite: v2 endpoints want granular scopes (`read:page:confluence`),
- * v1 endpoints want classic ones (`read:confluence-content.all`). An app that holds only one family gets this error
- * from the other.
+ * Under 3LO this is also how the two API versions bite: v2 endpoints want granular scopes (`read:page:confluence`), v1
+ * endpoints want classic ones (`read:confluence-content.all`). An app that holds only one family gets this error from
+ * the other.
  *
  * @stable
  */

--- a/src/core/errors/fromResponse.ts
+++ b/src/core/errors/fromResponse.ts
@@ -88,9 +88,9 @@ export function parseRetryAfter(header: string | null, now = Date.now()): number
 /**
  * Whether a 401 is really a missing scope.
  *
- * Confluence says so in the body — `{"code":401,"message":"Unauthorized; scope does not match"}` — and nowhere else,
- * so the message is the only signal there is. Matched loosely, since the wording is Atlassian's to change; a miss
- * only costs the caller a plain `AuthError`.
+ * Confluence says so in the body — `{"code":401,"message":"Unauthorized; scope does not match"}` — and nowhere else, so
+ * the message is the only signal there is. Matched loosely, since the wording is Atlassian's to change; a miss only
+ * costs the caller a plain `AuthError`.
  */
 function isScopeMismatch(body: unknown): boolean {
   const message = typeof body === 'object' && body !== null ? (body as { message?: unknown }).message : body;

--- a/src/core/formData/attachmentInput.ts
+++ b/src/core/formData/attachmentInput.ts
@@ -6,12 +6,7 @@
  * `AsyncIterable`, so both still fit — they just are not named here.
  */
 export type AttachmentContent =
-  | File
-  | Blob
-  | Uint8Array
-  | ReadableStream<Uint8Array | string>
-  | AsyncIterable<Uint8Array | string>
-  | string;
+  File | Blob | Uint8Array | ReadableStream<Uint8Array | string> | AsyncIterable<Uint8Array | string> | string;
 
 export type AttachmentInput = {
   filename: string;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -33,7 +33,6 @@ export { createClient } from './createClient.js';
 
 export type { Client } from './interfaces/index.js';
 
-
 export {
   httpMethodSchema,
   clientConfigSchema,

--- a/src/core/oauth/parseCallbackUrl.ts
+++ b/src/core/oauth/parseCallbackUrl.ts
@@ -35,12 +35,12 @@ function equals(a: string, b: string): boolean {
  *
  * Handles the three ways this step goes wrong, each of which is easy to forget by hand:
  *
- * - the user declined on the consent screen, so the URL carries `error=access_denied` and no code;
+ * - The user declined on the consent screen, so the URL carries `error=access_denied` and no code;
  * - `state` is missing or does not match the one you issued;
- * - the URL is simply not a callback — no code, no error.
+ * - The URL is simply not a callback — no code, no error.
  *
- * Each throws an {@link OAuthError}; for a decline, `error` is `access_denied`, which
- * {@link isReauthorizationRequired} recognises.
+ * Each throws an {@link OAuthError}; for a decline, `error` is `access_denied`, which {@link isReauthorizationRequired}
+ * recognises.
  *
  * @example
  *   ```typescript

--- a/src/core/productInfo.ts
+++ b/src/core/productInfo.ts
@@ -23,7 +23,8 @@ export const PRODUCT: ProductInfo = {
   gatewaySlug: 'confluence',
 
   /** Product-specific advice appended to a scope-mismatch 401, where the scope families differ per product. */
-  scopeHint: 'Note that v2 endpoints need granular scopes (read:page:confluence) while v1 endpoints need classic ones (read:confluence-content.all).',
+  scopeHint:
+    'Note that v2 endpoints need granular scopes (read:page:confluence) while v1 endpoints need classic ones (read:confluence-content.all).',
 };
 
 /**

--- a/src/v1/api/contentChildrenAndDescendants.ts
+++ b/src/v1/api/contentChildrenAndDescendants.ts
@@ -119,14 +119,8 @@ export async function getDescendantsOfType(client: Client, parameters: GetDescen
  * renaming page titles during the copy; for example, search and replace can be used in conjunction to rewrite the
  * copied page titles.
  *
- * Response example: <pre><code>
- *  {
- *       "id" : "1180606",
- *       "links" : {
- *            "status" : "/rest/api/longtask/1180606"
- *       }
- *  }
- *  </code></pre>
+ * Response example: <pre><code> { "id" : "1180606", "links" : { "status" : "/rest/api/longtask/1180606" } }
+ * </code></pre>
  *
  * Use the /longtask/<taskId> REST API to get the copy task status.
  */

--- a/src/v1/api/contentRestrictions.ts
+++ b/src/v1/api/contentRestrictions.ts
@@ -1,10 +1,14 @@
 import { ContentRestrictionArraySchema, type ContentRestrictionArray } from '../models/contentRestrictionArray';
+import {
+  GetRestrictionsByOperationSchema,
+  type GetRestrictionsByOperation,
+} from '../models/getRestrictionsByOperation';
 import { ContentRestrictionSchema, type ContentRestriction } from '../models/contentRestriction';
 import type { GetRestrictions } from '../parameters/getRestrictions';
 import type { AddRestrictions } from '../parameters/addRestrictions';
 import type { UpdateRestrictions } from '../parameters/updateRestrictions';
 import type { DeleteRestrictions } from '../parameters/deleteRestrictions';
-import type { GetRestrictionsByOperation } from '../parameters/getRestrictionsByOperation';
+import type { GetRestrictionsByOperation as GetRestrictionsByOperationParameters } from '../parameters/getRestrictionsByOperation';
 import type { GetRestrictionsForOperation } from '../parameters/getRestrictionsForOperation';
 import type { GetIndividualGroupRestrictionStatusByGroupId } from '../parameters/getIndividualGroupRestrictionStatusByGroupId';
 import type { AddGroupToContentRestrictionByGroupId } from '../parameters/addGroupToContentRestrictionByGroupId';
@@ -115,14 +119,15 @@ export async function deleteRestrictions(
  */
 export async function getRestrictionsByOperation(
   client: Client,
-  parameters: GetRestrictionsByOperation,
-): Promise<unknown> {
-  const config: SendRequestOptions<unknown> = {
+  parameters: GetRestrictionsByOperationParameters,
+): Promise<GetRestrictionsByOperation> {
+  const config: SendRequestOptions<GetRestrictionsByOperation> = {
     url: `/wiki/rest/api/content/${parameters.id}/restriction/byOperation`,
     method: 'GET',
     searchParams: {
       expand: parameters.expand,
     },
+    schema: GetRestrictionsByOperationSchema,
   };
 
   return await client.sendRequest(config);

--- a/src/v1/api/experimental.ts
+++ b/src/v1/api/experimental.ts
@@ -14,14 +14,8 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * This API accepts the pageTree delete request and returns a task ID. The delete process happens asynchronously.
  *
- * Response example: <pre><code>
- *  {
- *       "id" : "1180606",
- *       "links" : {
- *            "status" : "/rest/api/longtask/1180606"
- *       }
- *  }
- *  </code></pre>
+ * Response example: <pre><code> { "id" : "1180606", "links" : { "status" : "/rest/api/longtask/1180606" } }
+ * </code></pre>
  *
  * Use the `/longtask/<taskId>` REST API to get the copy task status.
  *

--- a/src/v1/createV1Client.ts
+++ b/src/v1/createV1Client.ts
@@ -172,6 +172,7 @@ import type {
   UserWatch,
   PermissionCheckResponse,
   ContentRestrictionArray,
+  GetRestrictionsByOperation as GetRestrictionsByOperationModel,
   ContentRestriction,
   ContentStateResponse,
   AvailableContentStates,
@@ -328,7 +329,7 @@ export function createV1Client(clientConfig: ClientConfig | Client) {
         contentRestrictions.updateRestrictions(client, parameters),
       deleteRestrictions: (parameters: DeleteRestrictions): Promise<ContentRestrictionArray> =>
         contentRestrictions.deleteRestrictions(client, parameters),
-      getRestrictionsByOperation: (parameters: GetRestrictionsByOperation): Promise<unknown> =>
+      getRestrictionsByOperation: (parameters: GetRestrictionsByOperation): Promise<GetRestrictionsByOperationModel> =>
         contentRestrictions.getRestrictionsByOperation(client, parameters),
       getRestrictionsForOperation: (parameters: GetRestrictionsForOperation): Promise<ContentRestriction> =>
         contentRestrictions.getRestrictionsForOperation(client, parameters),

--- a/src/v1/models/addContentRestriction.ts
+++ b/src/v1/models/addContentRestriction.ts
@@ -8,13 +8,13 @@ export const AddContentRestrictionSchema = apiObject({
   /** The restriction operation applied to content. */
   operation: z.enum(['read', 'update']),
   /**
-   * The users/groups that the restrictions will be applied to. At least one of `user` or `group` must be specified
-   * for this object.
+   * The users/groups that the restrictions will be applied to. At least one of `user` or `group` must be specified for
+   * this object.
    */
   restrictions: apiObject({
     /**
-     * The users that the restrictions will be applied to. This array must have at least one item, otherwise it
-     * should be omitted.
+     * The users that the restrictions will be applied to. This array must have at least one item, otherwise it should
+     * be omitted.
      */
     user: z
       .array(
@@ -28,8 +28,8 @@ export const AddContentRestrictionSchema = apiObject({
       )
       .optional(),
     /**
-     * The groups that the restrictions will be applied to. This array must have at least one item, otherwise it
-     * should be omitted.
+     * The groups that the restrictions will be applied to. This array must have at least one item, otherwise it should
+     * be omitted.
      */
     group: z
       .array(

--- a/src/v1/models/asyncContentBody.ts
+++ b/src/v1/models/asyncContentBody.ts
@@ -22,8 +22,8 @@ export const AsyncContentBodySchema = apiObject({
   renderTaskId: z.string().optional(),
   error: z.string().optional(),
   /**
-   * Rerunning is reserved for when the job is working, but there is a previous run's value in the cache. You may
-   * choose to continue polling, or use the cached value.
+   * Rerunning is reserved for when the job is working, but there is a previous run's value in the cache. You may choose
+   * to continue polling, or use the cached value.
    */
   status: z.enum(['WORKING', 'QUEUED', 'FAILED', 'COMPLETED', 'RERUNNING']).optional(),
   embeddedContent: z.array(EmbeddedContentSchema).optional(),

--- a/src/v1/models/availableContentStates.ts
+++ b/src/v1/models/availableContentStates.ts
@@ -4,16 +4,16 @@ import { ContentStateSchema } from './contentState';
 
 export const AvailableContentStatesSchema = apiObject({
   /**
-   * Space suggested content states that can be used in the space. This list can be empty if there are no space
-   * content states defined in the space or if space content states are disabled in the space. All spaces start with 4
-   * default space content states, and this can be modified in the UI under space settings.
+   * Space suggested content states that can be used in the space. This list can be empty if there are no space content
+   * states defined in the space or if space content states are disabled in the space. All spaces start with 4 default
+   * space content states, and this can be modified in the UI under space settings.
    */
   spaceContentStates: z.array(ContentStateSchema),
   /**
-   * Custom content states that can be used by the user on the content of this call. This list can be empty if there
-   * are no custom content states defined by the user or if custom content states are disabled in the space of the
-   * content. This will at most have 3 of the most recently published content states. Only the calling user has access
-   * to place these states on content, but all users can see these states once they are placed.
+   * Custom content states that can be used by the user on the content of this call. This list can be empty if there are
+   * no custom content states defined by the user or if custom content states are disabled in the space of the content.
+   * This will at most have 3 of the most recently published content states. Only the calling user has access to place
+   * these states on content, but all users can see these states once they are placed.
    */
   customContentStates: z.array(ContentStateSchema),
 });

--- a/src/v1/models/contentBodyConversionInput.ts
+++ b/src/v1/models/contentBodyConversionInput.ts
@@ -37,13 +37,13 @@ export const ContentBodyConversionInputSchema = apiObject({
    */
   embeddedContentRender: z.enum(['current', 'version-at-save']).optional(),
   /**
-   * A multi-value, comma-separated parameter indicating which properties of the content to expand and populate.
-   * Expands are dependent on the `to` conversion format and may be irrelevant for certain conversions (e.g.
+   * A multi-value, comma-separated parameter indicating which properties of the content to expand and populate. Expands
+   * are dependent on the `to` conversion format and may be irrelevant for certain conversions (e.g.
    * `macroRenderedOutput` is redundant when converting to `view` format).
    *
    * If rendering to `view` format, and the body content being converted includes arbitrary nested content (such as
-   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are
-   * the batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
+   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are the
+   * batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
    *
    * - `embeddedContent` returns metadata for nested content (e.g. page included using page include macro)
    * - `mediaToken` returns JWT token for retrieving attachment data from Media API

--- a/src/v1/models/contentCreate.ts
+++ b/src/v1/models/contentCreate.ts
@@ -70,9 +70,9 @@ export const ContentCreateSchema = apiObject({
     type: z.string(),
   }).nullish(),
   /**
-   * The parent content of the new content. If you are creating a top-level `page` or `comment`, this can be left
-   * blank. If you are creating a child page, this is where the parent page id goes. If you are creating a child
-   * comment, this is where the parent comment id goes. Only one parent content id can be specified.
+   * The parent content of the new content. If you are creating a top-level `page` or `comment`, this can be left blank.
+   * If you are creating a child page, this is where the parent page id goes. If you are creating a child comment, this
+   * is where the parent comment id goes. Only one parent content id can be specified.
    */
   ancestors: z
     .array(

--- a/src/v1/models/contentPropertyUpdate.ts
+++ b/src/v1/models/contentPropertyUpdate.ts
@@ -7,8 +7,8 @@ export const ContentPropertyUpdateSchema = apiObject({
   /** The version number of the property. */
   version: apiObject({
     /**
-     * The new version for the updated content property. Set this to the current version number incremented by one.
-     * To get the current version number, use 'Get content property' and retrieve `version.number`.
+     * The new version for the updated content property. Set this to the current version number incremented by one. To
+     * get the current version number, use 'Get content property' and retrieve `version.number`.
      */
     number: z.union([z.number(), z.string()]),
     /** If `minorEdit` is set to 'true', no notification email or activity stream will be generated for the change. */

--- a/src/v1/models/contentRestrictionUpdate.ts
+++ b/src/v1/models/contentRestrictionUpdate.ts
@@ -21,13 +21,13 @@ export const ContentRestrictionUpdateSchema = apiObject({
     'use',
   ]),
   /**
-   * The users/groups that the restrictions will be applied to. At least one of `user` or `group` must be specified
-   * for this object.
+   * The users/groups that the restrictions will be applied to. At least one of `user` or `group` must be specified for
+   * this object.
    */
   restrictions: apiObject({
     /**
-     * The groups that the restrictions will be applied to. This array must have at least one item, otherwise it
-     * should be omitted.
+     * The groups that the restrictions will be applied to. This array must have at least one item, otherwise it should
+     * be omitted.
      */
     group: z
       .array(

--- a/src/v1/models/contentUpdate.ts
+++ b/src/v1/models/contentUpdate.ts
@@ -5,8 +5,8 @@ import { ContentBodyCreateStorageSchema } from './contentBodyCreateStorage';
 
 export const ContentUpdateSchema = apiObject({
   /**
-   * The new version for the updated content. Set this to the current version number incremented by one, unless you
-   * are changing the status to 'draft' which must have a version number of 1.
+   * The new version for the updated content. Set this to the current version number incremented by one, unless you are
+   * changing the status to 'draft' which must have a version number of 1.
    *
    * To get the current version number, use [Get content by ID](#api-content-id-get) and retrieve `version.number`.
    */
@@ -27,8 +27,8 @@ export const ContentUpdateSchema = apiObject({
    */
   type: z.string().nullable(),
   /**
-   * The updated status of the content. Note, if you change the status of a page from 'current' to 'draft' and it has
-   * an existing draft, the existing draft will be deleted in favor of the updated page.
+   * The updated status of the content. Note, if you change the status of a page from 'current' to 'draft' and it has an
+   * existing draft, the existing draft will be deleted in favor of the updated page.
    */
   status: z.enum(['current', 'trashed', 'deleted', 'historical', 'draft']).optional(),
   /** The new parent for the content. Only one parent content 'id' can be specified. */
@@ -41,9 +41,9 @@ export const ContentUpdateSchema = apiObject({
     )
     .nullish(),
   /**
-   * The updated body of the content. Does not apply to attachments. If you are not sure how to generate these
-   * formats, you can create a page in the Confluence application, retrieve the content using [Get
-   * content](#api-content-get), and expand the desired content format, e.g. `expand=body.storage`.
+   * The updated body of the content. Does not apply to attachments. If you are not sure how to generate these formats,
+   * you can create a page in the Confluence application, retrieve the content using [Get content](#api-content-get),
+   * and expand the desired content format, e.g. `expand=body.storage`.
    */
   body: apiObject({
     view: ContentBodyCreateSchema.optional(),

--- a/src/v1/models/getRestrictionsByOperation.ts
+++ b/src/v1/models/getRestrictionsByOperation.ts
@@ -1,0 +1,12 @@
+import type { z } from 'zod';
+import { apiObject } from '#/core';
+import { ContentRestrictionSchema } from './contentRestriction';
+import { GenericLinksSchema } from './genericLinks';
+
+export const GetRestrictionsByOperationSchema = apiObject({
+  read: ContentRestrictionSchema.optional(),
+  update: ContentRestrictionSchema.optional(),
+  _links: GenericLinksSchema.optional(),
+});
+
+export type GetRestrictionsByOperation = z.infer<typeof GetRestrictionsByOperationSchema>;

--- a/src/v1/models/index.ts
+++ b/src/v1/models/index.ts
@@ -156,6 +156,8 @@ export * from './genericUserKey';
 
 export * from './genericUserName';
 
+export * from './getRestrictionsByOperation';
+
 export * from './getViewers';
 
 export * from './getViews';

--- a/src/v1/models/operationCheckResult.ts
+++ b/src/v1/models/operationCheckResult.ts
@@ -6,8 +6,9 @@ export const OperationCheckResultSchema = apiObject({
   /** The operation itself. */
   operation: z.string(),
   /**
-   * The space or content type that the operation applies to. Could be one of- - application - page - blogpost -
-   * comment - attachment - space
+   * The space or content type that the operation applies to. Could be one of- - application - page - blogpost - comment
+   *
+   * - Attachment - space
    */
   targetType: z.string(),
 });

--- a/src/v1/models/spaceCreate.ts
+++ b/src/v1/models/spaceCreate.ts
@@ -22,9 +22,9 @@ export const SpaceCreateSchema = apiObject({
   /**
    * The permissions for the new space. If no permissions are provided, the [Confluence default space
    * permissions](https://confluence.atlassian.com/x/UAgzKw#CreateaSpace-Spacepermissions) are applied. Note that if
-   * permissions are provided, the space is created with only the provided set of permissions, not including the
-   * default space permissions. Space permissions can be modified after creation using the space permissions
-   * endpoints, and a private space can be created using the create private space endpoint.
+   * permissions are provided, the space is created with only the provided set of permissions, not including the default
+   * space permissions. Space permissions can be modified after creation using the space permissions endpoints, and a
+   * private space can be created using the create private space endpoint.
    */
   permissions: z.array(SpacePermissionCreateSchema).nullish(),
 });

--- a/src/v1/models/spaceSettings.ts
+++ b/src/v1/models/spaceSettings.ts
@@ -16,9 +16,9 @@ export const SpaceSettingsSchema = apiObject({
     default: z.string(),
   }).optional(),
   /**
-   * The content rendering mode for the space. Controls spacing and typography in the editor and renderer. Valid
-   * values are "standard" and "compact". When set to "compact", content is rendered more densely with smaller spacing
-   * and typography.
+   * The content rendering mode for the space. Controls spacing and typography in the editor and renderer. Valid values
+   * are "standard" and "compact". When set to "compact", content is rendered more densely with smaller spacing and
+   * typography.
    */
   contentMode: z.enum(['standard', 'compact']).nullish(),
   spaceKey: z.string().optional(),

--- a/src/v1/models/spaceSettingsUpdate.ts
+++ b/src/v1/models/spaceSettingsUpdate.ts
@@ -10,9 +10,9 @@ export const SpaceSettingsUpdateSchema = apiObject({
    */
   routeOverrideEnabled: z.boolean().optional(),
   /**
-   * The content rendering mode for the space. Controls spacing and typography in the editor and renderer. Valid
-   * values are "standard" and "compact". When set to "compact", content is rendered more densely with smaller spacing
-   * and typography.
+   * The content rendering mode for the space. Controls spacing and typography in the editor and renderer. Valid values
+   * are "standard" and "compact". When set to "compact", content is rendered more densely with smaller spacing and
+   * typography.
    */
   contentMode: z.enum(['standard', 'compact']).nullish(),
 });

--- a/src/v1/models/userDetails.ts
+++ b/src/v1/models/userDetails.ts
@@ -5,47 +5,47 @@ export const UserDetailsSchema = apiObject({
   business: apiObject({
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     position: z.string().optional(),
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     department: z.string().optional(),
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     location: z.string().optional(),
   }).optional(),
   personal: apiObject({
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     phone: z.string().optional(),
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     im: z.string().optional(),
     /**
      * This property has been deprecated due to privacy changes. There is no replacement. See the [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     website: z.string().optional(),
     /**
      * This property has been deprecated due to privacy changes. Use the `User.email` property instead. See the
      * [migration
-     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-     * for details.
+     * guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+     * details.
      */
     email: z.string().optional(),
   }).optional(),

--- a/src/v1/parameters/addContentWatcher.ts
+++ b/src/v1/parameters/addContentWatcher.ts
@@ -4,22 +4,22 @@ export const AddContentWatcherSchema = z.object({
   /** The ID of the content to add the watcher to. */
   contentId: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/addLabelWatcher.ts
+++ b/src/v1/parameters/addLabelWatcher.ts
@@ -4,22 +4,22 @@ export const AddLabelWatcherSchema = z.object({
   /** The name of the label to add the watcher to. */
   labelName: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/addSpaceWatcher.ts
+++ b/src/v1/parameters/addSpaceWatcher.ts
@@ -4,22 +4,22 @@ export const AddSpaceWatcherSchema = z.object({
   /** The key of the space to add the watcher to. */
   spaceKey: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/addUserToContentRestriction.ts
+++ b/src/v1/parameters/addUserToContentRestriction.ts
@@ -6,22 +6,22 @@ export const AddUserToContentRestrictionSchema = z.object({
   /** The operation that the restriction applies to. */
   operationKey: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/createRelationship.ts
+++ b/src/v1/parameters/createRelationship.ts
@@ -10,11 +10,11 @@ export const CreateRelationshipSchema = z.object({
   sourceType: z.enum(['user', 'content', 'space']),
   /**
    * - The identifier for the source entity:
-   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `sourceType` is 'content', then specify the content ID.
    * - If `sourceType` is 'space', then specify the space key.
    */
@@ -26,11 +26,11 @@ export const CreateRelationshipSchema = z.object({
   targetType: z.enum(['user', 'content', 'space']),
   /**
    * - The identifier for the target entity:
-   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `targetType` is 'content', then specify the content ID.
    * - If `targetType` is 'space', then specify the space key.
    */
@@ -40,13 +40,13 @@ export const CreateRelationshipSchema = z.object({
   /** The status of the target. This parameter is only used when the `targetType` is 'content'. */
   targetStatus: z.string().optional(),
   /**
-   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus`
-   * is 'historical'.
+   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus` is
+   * 'historical'.
    */
   sourceVersion: z.number().optional(),
   /**
-   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus`
-   * is 'historical'.
+   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus` is
+   * 'historical'.
    */
   targetVersion: z.number().optional(),
 });

--- a/src/v1/parameters/deleteRelationship.ts
+++ b/src/v1/parameters/deleteRelationship.ts
@@ -7,11 +7,11 @@ export const DeleteRelationshipSchema = z.object({
   sourceType: z.enum(['user', 'content', 'space']),
   /**
    * - The identifier for the source entity:
-   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `sourceType` is 'content', then specify the content ID.
    * - If `sourceType` is 'space', then specify the space key.
    */
@@ -23,11 +23,11 @@ export const DeleteRelationshipSchema = z.object({
   targetType: z.enum(['user', 'content', 'space']),
   /**
    * - The identifier for the target entity:
-   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `targetType` is 'content', then specify the content ID.
    * - If `targetType` is 'space', then specify the space key.
    */
@@ -37,13 +37,13 @@ export const DeleteRelationshipSchema = z.object({
   /** The status of the target. This parameter is only used when the `targetType` is 'content'. */
   targetStatus: z.string().optional(),
   /**
-   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus`
-   * is 'historical'.
+   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus` is
+   * 'historical'.
    */
   sourceVersion: z.number().optional(),
   /**
-   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus`
-   * is 'historical'.
+   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus` is
+   * 'historical'.
    */
   targetVersion: z.number().optional(),
 });

--- a/src/v1/parameters/deleteUserProperty.ts
+++ b/src/v1/parameters/deleteUserProperty.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const DeleteUserPropertySchema = z.object({
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, 384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * 384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192
    */
   userId: z.string(),
   /** The key of the user property. */

--- a/src/v1/parameters/findSourcesForTarget.ts
+++ b/src/v1/parameters/findSourcesForTarget.ts
@@ -14,11 +14,11 @@ export const FindSourcesForTargetSchema = z.object({
   /**
    * The identifier for the target entity:
    *
-   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `targetType` is 'content', then specify the content ID.
    * - If `targetType` is 'space', then specify the space key.
    */
@@ -28,13 +28,13 @@ export const FindSourcesForTargetSchema = z.object({
   /** The status of the target. This parameter is only used when the `targetType` is 'content'. */
   targetStatus: z.string().optional(),
   /**
-   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus`
-   * is 'historical'.
+   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus` is
+   * 'historical'.
    */
   sourceVersion: z.number().optional(),
   /**
-   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus`
-   * is 'historical'.
+   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus` is
+   * 'historical'.
    */
   targetVersion: z.number().optional(),
   /**

--- a/src/v1/parameters/findTargetFromSource.ts
+++ b/src/v1/parameters/findTargetFromSource.ts
@@ -12,11 +12,11 @@ export const FindTargetFromSourceSchema = z.object({
   /**
    * The identifier for the source entity:
    *
-   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `sourceType` is 'content', then specify the content ID.
    * - If `sourceType` is 'space', then specify the space key.
    */
@@ -28,13 +28,13 @@ export const FindTargetFromSourceSchema = z.object({
   /** The status of the target. This parameter is only used when the `targetType` is 'content'. */
   targetStatus: z.string().optional(),
   /**
-   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus`
-   * is 'historical'.
+   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus` is
+   * 'historical'.
    */
   sourceVersion: z.number().optional(),
   /**
-   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus`
-   * is 'historical'.
+   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus` is
+   * 'historical'.
    */
   targetVersion: z.number().optional(),
   /**

--- a/src/v1/parameters/getAndAsyncConvertMacroBodyByMacroId.ts
+++ b/src/v1/parameters/getAndAsyncConvertMacroBodyByMacroId.ts
@@ -4,8 +4,8 @@ export const GetAndAsyncConvertMacroBodyByMacroIdSchema = z.object({
   /** The ID for the content that contains the macro. */
   id: z.string(),
   /**
-   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body
-   * for the latest content version.
+   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body for
+   * the latest content version.
    */
   version: z.number(),
   /**
@@ -23,13 +23,13 @@ export const GetAndAsyncConvertMacroBodyByMacroIdSchema = z.object({
    */
   to: z.enum(['export_view', 'view', 'styled_view']),
   /**
-   * A multi-value parameter indicating which properties of the content to expand and populate. Expands are dependent
-   * on the `to` conversion format and may be irrelevant for certain conversions (e.g. `macroRenderedOutput` is
-   * redundant when converting to `view` format).
+   * A multi-value parameter indicating which properties of the content to expand and populate. Expands are dependent on
+   * the `to` conversion format and may be irrelevant for certain conversions (e.g. `macroRenderedOutput` is redundant
+   * when converting to `view` format).
    *
    * If rendering to `view` format, and the body content being converted includes arbitrary nested content (such as
-   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are
-   * the batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
+   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are the
+   * batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
    *
    * - `embeddedContent` returns metadata for nested content (e.g. page included using page include macro)
    * - `mediaToken` returns JWT token for retrieving attachment data from Media API

--- a/src/v1/parameters/getAndConvertMacroBodyByMacroId.ts
+++ b/src/v1/parameters/getAndConvertMacroBodyByMacroId.ts
@@ -4,8 +4,8 @@ export const GetAndConvertMacroBodyByMacroIdSchema = z.object({
   /** The ID for the content that contains the macro. */
   id: z.string(),
   /**
-   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body
-   * for the latest content version.
+   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body for
+   * the latest content version.
    */
   version: z.number(),
   /**
@@ -17,13 +17,13 @@ export const GetAndConvertMacroBodyByMacroIdSchema = z.object({
   /** The content representation to return the macro in. */
   to: z.string(),
   /**
-   * A multi-value parameter indicating which properties of the content to expand and populate. Expands are dependent
-   * on the `to` conversion format and may be irrelevant for certain conversions (e.g. `macroRenderedOutput` is
-   * redundant when converting to `view` format).
+   * A multi-value parameter indicating which properties of the content to expand and populate. Expands are dependent on
+   * the `to` conversion format and may be irrelevant for certain conversions (e.g. `macroRenderedOutput` is redundant
+   * when converting to `view` format).
    *
    * If rendering to `view` format, and the body content being converted includes arbitrary nested content (such as
-   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are
-   * the batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
+   * macros); then it is necessary to include webresource expands in the request. Webresources for content body are the
+   * batched JS and CSS dependencies for any nested dynamic content (i.e. macros).
    *
    * - `embeddedContent` returns metadata for nested content (e.g. page included using page include macro)
    * - `mediaToken` returns JWT token for retrieving attachment data from Media API

--- a/src/v1/parameters/getContentRestrictionStatusForUser.ts
+++ b/src/v1/parameters/getContentRestrictionStatusForUser.ts
@@ -6,22 +6,22 @@ export const GetContentRestrictionStatusForUserSchema = z.object({
   /** The operation that is restricted. */
   operationKey: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/getContentWatchStatus.ts
+++ b/src/v1/parameters/getContentWatchStatus.ts
@@ -4,22 +4,22 @@ export const GetContentWatchStatusSchema = z.object({
   /** The ID of the content to be queried for whether the specified user is watching it. */
   contentId: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/getDescendantsOfType.ts
+++ b/src/v1/parameters/getDescendantsOfType.ts
@@ -7,15 +7,15 @@ export const GetDescendantsOfTypeSchema = z.object({
   type: z.enum(['page', 'comment', 'attachment']),
   /**
    * Filter the results to descendants upto a desired level of the content. Note, the maximum value supported is 100.
-   * root level of the content means immediate (level 1) descendants of the type requested. all represents returning
-   * all descendants of the type requested.
+   * root level of the content means immediate (level 1) descendants of the type requested. all represents returning all
+   * descendants of the type requested.
    */
   depth: z.string().optional(),
   /**
    * A multi-value parameter indicating which properties of the content to expand.
    *
-   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if
-   *   you only need to check whether the content has children of a particular type.
+   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if you
+   *   only need to check whether the content has children of a particular type.
    * - `childTypes.attachment` returns whether the content has attachments.
    * - `childTypes.comment` returns whether the content has comments.
    * - `childTypes.page` returns whether the content has child pages.
@@ -39,14 +39,14 @@ export const GetDescendantsOfTypeSchema = z.object({
    * - `children.attachment` returns all attachments for the content.
    * - `children.comment` returns all comments on the content.
    * - `restrictions.read.restrictions.user` returns the users that have permission to read the content.
-   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that
-   *   this may return deleted groups, because deleting a group doesn't remove associated restrictions.
+   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that this
+   *   may return deleted groups, because deleting a group doesn't remove associated restrictions.
    * - `restrictions.update.restrictions.user` returns the users that have permission to update the content.
    * - `restrictions.update.restrictions.group` returns the groups that have permission to update the content. Note that
    *   this may return deleted groups because deleting a group doesn't remove associated restrictions.
    * - `history` returns the history of the content, including the date it was created.
-   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it
-   *   and when it was updated.
+   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it and
+   *   when it was updated.
    * - `history.previousVersion` returns information about the update prior to the current content update.
    * - `history.contributors` returns all of the users who have contributed to the content.
    * - `history.nextVersion` returns information about the update after to the current content update.
@@ -55,8 +55,8 @@ export const GetDescendantsOfTypeSchema = z.object({
    *   format.
    * - `body.storage` returns the body of content in storage format.
    * - `body.view` returns the body of content in view format.
-   * - `version` returns information about the most recent update of the content, including who updated it and when it
-   *   was updated.
+   * - `version` returns information about the most recent update of the content, including who updated it and when it was
+   *   updated.
    * - `descendants.page` returns pages that are descendants at any level below the content.
    * - `descendants.whiteboard` returns whiteboards that are descendants at any level below the content.
    * - `descendants.database` returns databases that are descendants at any level below the content.

--- a/src/v1/parameters/getGroupMembershipsForUser.ts
+++ b/src/v1/parameters/getGroupMembershipsForUser.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const GetGroupMembershipsForUserSchema = z.object({
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string(),
   /** The starting index of the returned groups. */

--- a/src/v1/parameters/getMacroBodyByMacroId.ts
+++ b/src/v1/parameters/getMacroBodyByMacroId.ts
@@ -4,8 +4,8 @@ export const GetMacroBodyByMacroIdSchema = z.object({
   /** The ID for the content that contains the macro. */
   id: z.string(),
   /**
-   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body
-   * for the latest content version.
+   * The version of the content that contains the macro. Specifying `0` as the `version` will return the macro body for
+   * the latest content version.
    */
   version: z.number(),
   /**

--- a/src/v1/parameters/getRelationship.ts
+++ b/src/v1/parameters/getRelationship.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const GetRelationshipSchema = z.object({
   /**
-   * The name of the relationship. This method supports the 'favourite' (i.e. 'save for later') relationship as well
-   * as any other relationship types created via [Create
+   * The name of the relationship. This method supports the 'favourite' (i.e. 'save for later') relationship as well as
+   * any other relationship types created via [Create
    * relationship](#api-wiki-rest-api-relation-relationname-from-sourcetype-sourcekey-to-targettype-targetkey-put).
    */
   relationName: z.string(),
@@ -11,11 +11,11 @@ export const GetRelationshipSchema = z.object({
   sourceType: z.enum(['user', 'content', 'space']),
   /**
    * - The identifier for the source entity:
-   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `sourceType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `sourceType` is 'content', then specify the content ID.
    * - If `sourceType` is 'space', then specify the space key.
    */
@@ -28,11 +28,11 @@ export const GetRelationshipSchema = z.object({
   /**
    * The identifier for the target entity:
    *
-   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the
-   *   account ID of the user. Note that the user key has been deprecated in favor of the account ID for this
-   *   parameter. See the [migration
-   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   *   for details.
+   * - If `targetType` is `user`, then specify either `current` (logged-in user), the user key of the user, or the account
+   *   ID of the user. Note that the user key has been deprecated in favor of the account ID for this parameter. See the
+   *   [migration
+   *   guide](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   *   details.
    * - If `targetType` is 'content', then specify the content ID.
    * - If `targetType` is 'space', then specify the space key.
    */
@@ -42,13 +42,13 @@ export const GetRelationshipSchema = z.object({
   /** The status of the target. This parameter is only used when the `targetType` is 'content'. */
   targetStatus: z.string().optional(),
   /**
-   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus`
-   * is 'historical'.
+   * The version of the source. This parameter is only used when the `sourceType` is 'content' and the `sourceStatus` is
+   * 'historical'.
    */
   sourceVersion: z.number().optional(),
   /**
-   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus`
-   * is 'historical'.
+   * The version of the target. This parameter is only used when the `targetType` is 'content' and the `targetStatus` is
+   * 'historical'.
    */
   targetVersion: z.number().optional(),
   /**

--- a/src/v1/parameters/getUser.ts
+++ b/src/v1/parameters/getUser.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const GetUserSchema = z.object({
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string(),
   /**

--- a/src/v1/parameters/isWatchingLabel.ts
+++ b/src/v1/parameters/isWatchingLabel.ts
@@ -4,22 +4,22 @@ export const IsWatchingLabelSchema = z.object({
   /** The name of the label to be queried for whether the specified user is watching it. */
   labelName: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/isWatchingSpace.ts
+++ b/src/v1/parameters/isWatchingSpace.ts
@@ -4,22 +4,22 @@ export const IsWatchingSpaceSchema = z.object({
   /** The key of the space to be queried for whether the specified user is watching it. */
   spaceKey: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/publishLegacyDraft.ts
+++ b/src/v1/parameters/publishLegacyDraft.ts
@@ -15,8 +15,8 @@ export const PublishLegacyDraftSchema = z.object({
   /**
    * A multi-value parameter indicating which properties of the content to expand.
    *
-   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if
-   *   you only need to check whether the content has children of a particular type.
+   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if you
+   *   only need to check whether the content has children of a particular type.
    * - `childTypes.attachment` returns whether the content has attachments.
    * - `childTypes.comment` returns whether the content has comments.
    * - `childTypes.page` returns whether the content has child pages.
@@ -40,14 +40,14 @@ export const PublishLegacyDraftSchema = z.object({
    * - `children.attachment` returns all attachments for the content.
    * - `children.comment` returns all comments on the content.
    * - `restrictions.read.restrictions.user` returns the users that have permission to read the content.
-   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that
-   *   this may return deleted groups, because deleting a group doesn't remove associated restrictions.
+   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that this
+   *   may return deleted groups, because deleting a group doesn't remove associated restrictions.
    * - `restrictions.update.restrictions.user` returns the users that have permission to update the content.
    * - `restrictions.update.restrictions.group` returns the groups that have permission to update the content. Note that
    *   this may return deleted groups because deleting a group doesn't remove associated restrictions.
    * - `history` returns the history of the content, including the date it was created.
-   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it
-   *   and when it was updated.
+   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it and
+   *   when it was updated.
    * - `history.previousVersion` returns information about the update prior to the current content update.
    * - `history.contributors` returns all of the users who have contributed to the content.
    * - `history.nextVersion` returns information about the update after to the current content update.
@@ -56,8 +56,8 @@ export const PublishLegacyDraftSchema = z.object({
    *   format.
    * - `body.storage` returns the body of content in storage format.
    * - `body.view` returns the body of content in view format.
-   * - `version` returns information about the most recent update of the content, including who updated it and when it
-   *   was updated.
+   * - `version` returns information about the most recent update of the content, including who updated it and when it was
+   *   updated.
    * - `descendants.page` returns pages that are descendants at any level below the content.
    * - `descendants.whiteboard` returns whiteboards that are descendants at any level below the content.
    * - `descendants.database` returns databases that are descendants at any level below the content.

--- a/src/v1/parameters/publishSharedDraft.ts
+++ b/src/v1/parameters/publishSharedDraft.ts
@@ -15,8 +15,8 @@ export const PublishSharedDraftSchema = z.object({
   /**
    * A multi-value parameter indicating which properties of the content to expand.
    *
-   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if
-   *   you only need to check whether the content has children of a particular type.
+   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if you
+   *   only need to check whether the content has children of a particular type.
    * - `childTypes.attachment` returns whether the content has attachments.
    * - `childTypes.comment` returns whether the content has comments.
    * - `childTypes.page` returns whether the content has child pages.
@@ -40,14 +40,14 @@ export const PublishSharedDraftSchema = z.object({
    * - `children.attachment` returns all attachments for the content.
    * - `children.comment` returns all comments on the content.
    * - `restrictions.read.restrictions.user` returns the users that have permission to read the content.
-   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that
-   *   this may return deleted groups, because deleting a group doesn't remove associated restrictions.
+   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that this
+   *   may return deleted groups, because deleting a group doesn't remove associated restrictions.
    * - `restrictions.update.restrictions.user` returns the users that have permission to update the content.
    * - `restrictions.update.restrictions.group` returns the groups that have permission to update the content. Note that
    *   this may return deleted groups because deleting a group doesn't remove associated restrictions.
    * - `history` returns the history of the content, including the date it was created.
-   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it
-   *   and when it was updated.
+   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it and
+   *   when it was updated.
    * - `history.previousVersion` returns information about the update prior to the current content update.
    * - `history.contributors` returns all of the users who have contributed to the content.
    * - `history.nextVersion` returns information about the update after to the current content update.
@@ -56,8 +56,8 @@ export const PublishSharedDraftSchema = z.object({
    *   format.
    * - `body.storage` returns the body of content in storage format.
    * - `body.view` returns the body of content in view format.
-   * - `version` returns information about the most recent update of the content, including who updated it and when it
-   *   was updated.
+   * - `version` returns information about the most recent update of the content, including who updated it and when it was
+   *   updated.
    * - `descendants.page` returns pages that are descendants at any level below the content.
    * - `descendants.whiteboard` returns whiteboards that are descendants at any level below the content.
    * - `descendants.database` returns databases that are descendants at any level below the content.

--- a/src/v1/parameters/removeContentWatcher.ts
+++ b/src/v1/parameters/removeContentWatcher.ts
@@ -4,22 +4,22 @@ export const RemoveContentWatcherSchema = z.object({
   /** The ID of the content to remove the watcher from. */
   contentId: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/removeLabelWatcher.ts
+++ b/src/v1/parameters/removeLabelWatcher.ts
@@ -4,22 +4,22 @@ export const RemoveLabelWatcherSchema = z.object({
   /** The name of the label to remove the watcher from. */
   labelName: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/removeMemberFromGroupByGroupId.ts
+++ b/src/v1/parameters/removeMemberFromGroupByGroupId.ts
@@ -4,22 +4,22 @@ export const RemoveMemberFromGroupByGroupIdSchema = z.object({
   /** Id of the group whose membership is updated. */
   groupId: z.string(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
 });

--- a/src/v1/parameters/removeSpaceWatch.ts
+++ b/src/v1/parameters/removeSpaceWatch.ts
@@ -4,22 +4,22 @@ export const RemoveSpaceWatchSchema = z.object({
   /** The key of the space to remove the watcher from. */
   spaceKey: z.string(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/removeUserFromContentRestriction.ts
+++ b/src/v1/parameters/removeUserFromContentRestriction.ts
@@ -6,22 +6,22 @@ export const RemoveUserFromContentRestrictionSchema = z.object({
   /** The operation that the restriction applies to. */
   operationKey: z.enum(['read', 'update']),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   key: z.string().optional(),
   /**
-   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead.
-   * See the [deprecation
-   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/)
-   * for details.
+   * This parameter is no longer available and will be removed from the documentation soon. Use `accountId` instead. See
+   * the [deprecation
+   * notice](https://developer.atlassian.com/cloud/confluence/deprecation-notice-user-privacy-api-migration-guide/) for
+   * details.
    */
   username: z.string().optional(),
   /**
-   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For
-   * example, `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
+   * The account ID of the user. The accountId uniquely identifies the user across all Atlassian products. For example,
+   * `384093:32b4d9w0-f6a5-3535-11a3-9c8c88d10192`.
    */
   accountId: z.string().optional(),
 });

--- a/src/v1/parameters/searchByCQL.ts
+++ b/src/v1/parameters/searchByCQL.ts
@@ -14,8 +14,7 @@ export const SearchByCQLSchema = z.object({
    * - `contentId` ID of the content to search against. Optional. Must be in the space specified by `spaceKey`.
    * - `contentStatuses` Content statuses to search against. Optional.
    *
-   * Specify these values in an object. For example, `cqlcontext={%22spaceKey%22:%22TEST%22,
-   * %22contentId%22:%22123%22}`
+   * Specify these values in an object. For example, `cqlcontext={%22spaceKey%22:%22TEST%22, %22contentId%22:%22123%22}`
    */
   cqlcontext: z.string().optional(),
   /** Pointer to a set of search results, returned as part of the `next` or `prev` URL from the previous search call. */

--- a/src/v1/parameters/searchContentByCQL.ts
+++ b/src/v1/parameters/searchContentByCQL.ts
@@ -4,8 +4,8 @@ export const SearchContentByCQLSchema = z.object({
   /** The CQL string that is used to find the requested content. */
   cql: z.string(),
   /**
-   * The space, content, and content status to execute the search against. Specify this as an object with the
-   * following properties:
+   * The space, content, and content status to execute the search against. Specify this as an object with the following
+   * properties:
    *
    * - `spaceKey` Key of the space to search against. Optional.
    * - `contentId` ID of the content to search against. Optional. Must be in the space spacified by `spaceKey`.
@@ -15,8 +15,8 @@ export const SearchContentByCQLSchema = z.object({
   /**
    * A multi-value parameter indicating which properties of the content to expand.
    *
-   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if
-   *   you only need to check whether the content has children of a particular type.
+   * - `childTypes.all` returns whether the content has attachments, comments, or child pages/whiteboards. Use this if you
+   *   only need to check whether the content has children of a particular type.
    * - `childTypes.attachment` returns whether the content has attachments.
    * - `childTypes.comment` returns whether the content has comments.
    * - `childTypes.page` returns whether the content has child pages.
@@ -40,14 +40,14 @@ export const SearchContentByCQLSchema = z.object({
    * - `children.attachment` returns all attachments for the content.
    * - `children.comment` returns all comments on the content.
    * - `restrictions.read.restrictions.user` returns the users that have permission to read the content.
-   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that
-   *   this may return deleted groups, because deleting a group doesn't remove associated restrictions.
+   * - `restrictions.read.restrictions.group` returns the groups that have permission to read the content. Note that this
+   *   may return deleted groups, because deleting a group doesn't remove associated restrictions.
    * - `restrictions.update.restrictions.user` returns the users that have permission to update the content.
    * - `restrictions.update.restrictions.group` returns the groups that have permission to update the content. Note that
    *   this may return deleted groups because deleting a group doesn't remove associated restrictions.
    * - `history` returns the history of the content, including the date it was created.
-   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it
-   *   and when it was updated.
+   * - `history.lastUpdated` returns information about the most recent update of the content, including who updated it and
+   *   when it was updated.
    * - `history.previousVersion` returns information about the update prior to the current content update.
    * - `history.contributors` returns all of the users who have contributed to the content.
    * - `history.nextVersion` returns information about the update after to the current content update.
@@ -56,8 +56,8 @@ export const SearchContentByCQLSchema = z.object({
    *   format.
    * - `body.storage` returns the body of content in storage format.
    * - `body.view` returns the body of content in view format.
-   * - `version` returns information about the most recent update of the content, including who updated it and when it
-   *   was updated.
+   * - `version` returns information about the most recent update of the content, including who updated it and when it was
+   *   updated.
    * - `descendants.page` returns pages that are descendants at any level below the content.
    * - `descendants.whiteboard` returns whiteboards that are descendants at any level below the content.
    * - `descendants.database` returns databases that are descendants at any level below the content.

--- a/src/v1/parameters/searchUser.ts
+++ b/src/v1/parameters/searchUser.ts
@@ -7,9 +7,9 @@ export const SearchUserSchema = z.object({
    * build a CQL query.
    *
    * Example queries: cql=type=user will return up to 10k users cql=user="1234" will return user with accountId "1234"
-   * You can also use IN, NOT IN, != operators cql=user IN ("12", "34") will return users with accountids "12" and
-   * "34" cql=user.fullname~jo will return users with nickname/full name starting with "jo" cql=user.accountid="123"
-   * will return user with accountId "123"
+   * You can also use IN, NOT IN, != operators cql=user IN ("12", "34") will return users with accountids "12" and "34"
+   * cql=user.fullname~jo will return users with nickname/full name starting with "jo" cql=user.accountid="123" will
+   * return user with accountId "123"
    */
   cql: z.string(),
   /** The starting index of the returned users. */

--- a/src/v2/api/classificationLevel.ts
+++ b/src/v2/api/classificationLevel.ts
@@ -207,8 +207,7 @@ export async function putBlogPostClassificationLevel(
 
 /**
  * Resets the [classification level](https://developer.atlassian.com/cloud/admin/dlp/rest/intro/#Classification%20level)
- * for a specific blog post for the space\
- * [default classification
+ * for a specific blog post for the space [default classification
  * level](https://support.atlassian.com/security-and-access-policies/docs/what-is-a-default-classification-level/).
  *
  * **[Permissions](https://confluence.atlassian.com/x/_AozKw) required**: 'Permission to access the Confluence site

--- a/src/v2/models/bulkTransitionCombinationEntry.ts
+++ b/src/v2/models/bulkTransitionCombinationEntry.ts
@@ -4,8 +4,8 @@ import { BulkTransitionDecodedPermissionSchema } from './bulkTransitionDecodedPe
 
 export const BulkTransitionCombinationEntrySchema = apiObject({
   /**
-   * The opaque id identifying this unique combination of space permissions. Pass directly to the bulk
-   * role-assignments or access-removals endpoints.
+   * The opaque id identifying this unique combination of space permissions. Pass directly to the bulk role-assignments
+   * or access-removals endpoints.
    */
   combinationId: z.string(),
   /** Number of spaces that currently have this combination. */

--- a/src/v2/models/createInlineCommentModel.ts
+++ b/src/v2/models/createInlineCommentModel.ts
@@ -21,14 +21,11 @@ export const CreateInlineCommentModelSchema = apiObject({
   inlineCommentProperties: apiObject({
     /** The text to highlight */
     textSelection: z.string().optional(),
-    /**
-     * The number of matches for the selected text on the page (should be strictly greater than
-     * textSelectionMatchIndex)
-     */
+    /** The number of matches for the selected text on the page (should be strictly greater than textSelectionMatchIndex) */
     textSelectionMatchCount: z.number().optional(),
     /**
-     * The match index to highlight. This is zero-based. E.g. if you have 3 occurrences of "hello world" on a page
-     * and you want to highlight the second occurrence, you should pass 1 for textSelectionMatchIndex and 3 for
+     * The match index to highlight. This is zero-based. E.g. if you have 3 occurrences of "hello world" on a page and
+     * you want to highlight the second occurrence, you should pass 1 for textSelectionMatchIndex and 3 for
      * textSelectionMatchCount.
      */
     textSelectionMatchIndex: z.number().optional(),

--- a/src/v2/models/inlineComment.ts
+++ b/src/v2/models/inlineComment.ts
@@ -30,10 +30,7 @@ export const InlineCommentSchema = apiObject({
    * or reopened.
    */
   resolutionLastModifierId: z.string().optional(),
-  /**
-   * Timestamp of the last modification to the comment's resolution status. Null until comment is resolved or
-   * reopened.
-   */
+  /** Timestamp of the last modification to the comment's resolution status. Null until comment is resolved or reopened. */
   resolutionLastModifiedAt: z.coerce.date().optional(),
   resolutionStatus: InlineCommentResolutionStatusSchema.optional(),
   properties: apiObject({

--- a/src/v2/models/listSpacePermissionCombinationsResponse.ts
+++ b/src/v2/models/listSpacePermissionCombinationsResponse.ts
@@ -6,8 +6,8 @@ export const ListSpacePermissionCombinationsResponseSchema = apiObject({
   /** One page of unassigned permission combinations, sorted by principalCount descending. */
   results: z.array(BulkTransitionCombinationEntrySchema),
   /**
-   * ISO-8601 timestamp of the last audit run that populated the combinations table. Absent if the audit task has
-   * never run on this tenant.
+   * ISO-8601 timestamp of the last audit run that populated the combinations table. Absent if the audit task has never
+   * run on this tenant.
    */
   generatedAt: z.string().nullish(),
   /** Opaque cursor for the next page. Absent when no further results exist. */

--- a/src/v2/models/space.ts
+++ b/src/v2/models/space.ts
@@ -52,7 +52,8 @@ export const SpaceSchema = apiObject({
     _links: OptionalFieldLinksSchema.nullish(),
   }).nullish(),
   _links: SpaceLinksSchema.nullish(),
-  currentActiveAlias: z.string().optional(),
+  /** Currently active alias for a Confluence space. Returned as null when the space has none. */
+  currentActiveAlias: z.string().nullish(),
 });
 
 export type Space = z.infer<typeof SpaceSchema>;

--- a/src/v2/models/spaceIcon.ts
+++ b/src/v2/models/spaceIcon.ts
@@ -9,8 +9,8 @@ export const SpaceIconSchema = apiObject({
    */
   path: z.string().optional(),
   /**
-   * The path (relative to base URL) that can be used to retrieve a link to download the space icon. 3LO apps should
-   * use this link instead of the value provided in the `path` property to retrieve the icon.
+   * The path (relative to base URL) that can be used to retrieve a link to download the space icon. 3LO apps should use
+   * this link instead of the value provided in the `path` property to retrieve the icon.
    *
    * Currently this field is only returned for `global` spaces and not `personal` spaces.
    */

--- a/src/v2/models/spaceSummary.ts
+++ b/src/v2/models/spaceSummary.ts
@@ -20,7 +20,7 @@ export const SpaceSummarySchema = apiObject({
   /** The account ID of the user who owns this space. */
   spaceOwnerId: z.string().optional(),
   /** Currently active alias for a Confluence space. */
-  currentActiveAlias: z.string().optional(),
+  currentActiveAlias: z.string().nullish(),
   /** Date and time when the space was created. In format "YYYY-MM-DDTHH:mm:ss.sssZ". */
   createdAt: z.coerce.date().optional(),
   /** ID of the space's homepage. */

--- a/src/v2/models/updateInlineCommentModel.ts
+++ b/src/v2/models/updateInlineCommentModel.ts
@@ -13,8 +13,8 @@ export const UpdateInlineCommentModelSchema = apiObject({
   body: z.union([CommentBodyWriteSchema, CommentNestedBodyWriteSchema]).nullish(),
   /**
    * Resolved state of the comment. Set to true to resolve the comment, set to false to reopen it. If matching the
-   * existing state (i.e. true -> resolved or false -> open/reopened) , no change will occur. A dangling comment
-   * cannot be updated.
+   * existing state (i.e. true -> resolved or false -> open/reopened) , no change will occur. A dangling comment cannot
+   * be updated.
    */
   resolved: z.boolean().optional(),
 });

--- a/src/v2/parameters/createBlogPost.ts
+++ b/src/v2/parameters/createBlogPost.ts
@@ -1,10 +1,7 @@
 import { z } from 'zod';
 
 export const CreateBlogPostSchema = z.object({
-  /**
-   * The blog post will be private. Only the user who creates this blog post will have permission to view and edit
-   * one.
-   */
+  /** The blog post will be private. Only the user who creates this blog post will have permission to view and edit one. */
   private: z.boolean().optional(),
   body: z.record(z.string(), z.any()).optional(),
 });

--- a/src/v2/parameters/getAttachmentById.ts
+++ b/src/v2/parameters/getAttachmentById.ts
@@ -18,9 +18,9 @@ export const GetAttachmentByIdSchema = z.object({
    */
   includeLabels: z.boolean().optional(),
   /**
-   * Includes content properties associated with this attachment in the response. The number of results will be
-   * limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if
-   * more results are available and a link to retrieve the rest of the results.
+   * Includes content properties associated with this attachment in the response. The number of results will be limited
+   * to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
+   * results are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
   /**
@@ -30,9 +30,9 @@ export const GetAttachmentByIdSchema = z.object({
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes versions associated with this attachment in the response. The number of results will be limited to 50
-   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
-   * are available and a link to retrieve the rest of the results.
+   * Includes versions associated with this attachment in the response. The number of results will be limited to 50 and
+   * sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
+   * available and a link to retrieve the rest of the results.
    */
   includeVersions: z.boolean().optional(),
   /**

--- a/src/v2/parameters/getAttachmentLabels.ts
+++ b/src/v2/parameters/getAttachmentLabels.ts
@@ -13,8 +13,8 @@ export const GetAttachmentLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getAvailableSpacePermissions.ts
+++ b/src/v2/parameters/getAvailableSpacePermissions.ts
@@ -7,8 +7,8 @@ export const GetAvailableSpacePermissionsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of space permissions to return. If more results exist, use the `Link` response header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of space permissions to return. If more results exist, use the `Link` response header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getAvailableSpaceRoles.ts
+++ b/src/v2/parameters/getAvailableSpaceRoles.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import { PrincipalTypeSchema } from '../models';
 
 export const GetAvailableSpaceRolesSchema = z.object({
-  /**
-   * The space ID for which to filter available space roles; if empty, return all available space roles for the
-   * tenant.
-   */
+  /** The space ID for which to filter available space roles; if empty, return all available space roles for the tenant. */
   spaceId: z.string().optional(),
   /** The space role type to filter results by. */
   roleType: z.string().optional(),

--- a/src/v2/parameters/getBlogPostById.ts
+++ b/src/v2/parameters/getBlogPostById.ts
@@ -8,8 +8,8 @@ export const GetBlogPostByIdSchema = z.object({
    */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSingleSchema.optional(),
   /** Retrieve the draft version of this blog post. */
@@ -52,8 +52,8 @@ export const GetBlogPostByIdSchema = z.object({
    */
   includeVersions: z.boolean().optional(),
   /**
-   * Includes the current version associated with this blog post in the response. By default this is included and can
-   * be omitted by setting the value to `false`.
+   * Includes the current version associated with this blog post in the response. By default this is included and can be
+   * omitted by setting the value to `false`.
    */
   includeVersion: z.boolean().optional(),
   /** Includes whether this blog post has been favorited by the current user. */

--- a/src/v2/parameters/getBlogPostFooterComments.ts
+++ b/src/v2/parameters/getBlogPostFooterComments.ts
@@ -20,8 +20,8 @@ export const GetBlogPostFooterCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getBlogPostInlineComments.ts
+++ b/src/v2/parameters/getBlogPostInlineComments.ts
@@ -22,8 +22,8 @@ export const GetBlogPostInlineCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of inline comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of inline comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getBlogPostLabels.ts
+++ b/src/v2/parameters/getBlogPostLabels.ts
@@ -13,8 +13,8 @@ export const GetBlogPostLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getBlogPostVersions.ts
+++ b/src/v2/parameters/getBlogPostVersions.ts
@@ -4,13 +4,13 @@ import { VersionSortOrderSchema } from '../models';
 
 export const GetBlogPostVersionsSchema = z.object({
   /**
-   * The ID of the blog post to be queried for its versions. If you don't know the blog post ID, use Get blog posts
-   * and filter the results.
+   * The ID of the blog post to be queried for its versions. If you don't know the blog post ID, use Get blog posts and
+   * filter the results.
    */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getBlogPosts.ts
+++ b/src/v2/parameters/getBlogPosts.ts
@@ -14,8 +14,8 @@ export const GetBlogPostsSchema = z.object({
   /** Filter the results to blog posts based on their title. */
   title: z.string().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getBlogPostsInSpace.ts
+++ b/src/v2/parameters/getBlogPostsInSpace.ts
@@ -12,8 +12,8 @@ export const GetBlogPostsInSpaceSchema = z.object({
   /** Filter the results to blog posts based on their title. */
   title: z.string().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getChildCustomContent.ts
+++ b/src/v2/parameters/getChildCustomContent.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const GetChildCustomContentSchema = z.object({
   /**
-   * The ID of the parent custom content. If you don't know the custom content ID, use Get custom-content and filter
-   * the results.
+   * The ID of the parent custom content. If you don't know the custom content ID, use Get custom-content and filter the
+   * results.
    */
   id: z.number(),
   /**

--- a/src/v2/parameters/getCustomContentById.ts
+++ b/src/v2/parameters/getCustomContentById.ts
@@ -8,8 +8,8 @@ export const GetCustomContentByIdSchema = z.object({
    */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.
@@ -33,15 +33,15 @@ export const GetCustomContentByIdSchema = z.object({
    */
   includeProperties: z.boolean().optional(),
   /**
-   * Includes operations associated with this custom content in the response, as defined in the `Operation` object.
-   * The number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property
-   * will be present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this custom content in the response, as defined in the `Operation` object. The
+   * number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will
+   * be present to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes versions associated with this custom content in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes versions associated with this custom content in the response. The number of results will be limited to 50
+   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeVersions: z.boolean().optional(),
   /**

--- a/src/v2/parameters/getCustomContentByType.ts
+++ b/src/v2/parameters/getCustomContentByType.ts
@@ -28,8 +28,8 @@ export const GetCustomContentByTypeSchema = z.object({
    */
   limit: z.number().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.

--- a/src/v2/parameters/getCustomContentByTypeInBlogPost.ts
+++ b/src/v2/parameters/getCustomContentByTypeInBlogPost.ts
@@ -23,8 +23,8 @@ export const GetCustomContentByTypeInBlogPostSchema = z.object({
    */
   limit: z.number().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.

--- a/src/v2/parameters/getCustomContentByTypeInPage.ts
+++ b/src/v2/parameters/getCustomContentByTypeInPage.ts
@@ -23,8 +23,8 @@ export const GetCustomContentByTypeInPageSchema = z.object({
    */
   limit: z.number().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.

--- a/src/v2/parameters/getCustomContentByTypeInSpace.ts
+++ b/src/v2/parameters/getCustomContentByTypeInSpace.ts
@@ -20,8 +20,8 @@ export const GetCustomContentByTypeInSpaceSchema = z.object({
    */
   limit: z.number().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.

--- a/src/v2/parameters/getCustomContentLabels.ts
+++ b/src/v2/parameters/getCustomContentLabels.ts
@@ -13,8 +13,8 @@ export const GetCustomContentLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getCustomContentVersions.ts
+++ b/src/v2/parameters/getCustomContentVersions.ts
@@ -9,8 +9,8 @@ export const GetCustomContentVersionsSchema = z.object({
    */
   customContentId: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    *
    * Note: If the custom content body type is `storage`, the `storage` and `atlas_doc_format` body formats are able to
    * be returned. If the custom content body type is `raw`, only the `raw` body format is able to be returned.

--- a/src/v2/parameters/getDataPolicySpaces.ts
+++ b/src/v2/parameters/getDataPolicySpaces.ts
@@ -14,8 +14,8 @@ export const GetDataPolicySpacesSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of spaces per result to return. If more results exist, use the `Link` response header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of spaces per result to return. If more results exist, use the `Link` response header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getDatabaseAncestors.ts
+++ b/src/v2/parameters/getDatabaseAncestors.ts
@@ -4,8 +4,8 @@ export const GetDatabaseAncestorsSchema = z.object({
   /** The ID of the database. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest
-   * ancestor's ID to fetch the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest ancestor's
+   * ID to fetch the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getDatabaseById.ts
+++ b/src/v2/parameters/getDatabaseById.ts
@@ -8,15 +8,15 @@ export const GetDatabaseByIdSchema = z.object({
   /** Includes direct children of the database, as defined in the `ChildrenResponse` object. */
   includeDirectChildren: z.boolean().optional(),
   /**
-   * Includes operations associated with this database in the response, as defined in the `Operation` object. The
-   * number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will
-   * be present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this database in the response, as defined in the `Operation` object. The number
+   * of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be
+   * present to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes content properties associated with this database in the response. The number of results will be limited
-   * to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes content properties associated with this database in the response. The number of results will be limited to
+   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
 });

--- a/src/v2/parameters/getDatabaseDescendants.ts
+++ b/src/v2/parameters/getDatabaseDescendants.ts
@@ -4,13 +4,13 @@ export const GetDatabaseDescendantsSchema = z.object({
   /** The ID of the database. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch
-   * the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch the
+   * next set of results.
    */
   limit: z.number().optional(),
   /**
-   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the
-   * content type of the deepest descendant to fetch more descendants.
+   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the content
+   * type of the deepest descendant to fetch more descendants.
    */
   depth: z.number().optional(),
   /**

--- a/src/v2/parameters/getFolderAncestors.ts
+++ b/src/v2/parameters/getFolderAncestors.ts
@@ -4,8 +4,8 @@ export const GetFolderAncestorsSchema = z.object({
   /** The ID of the folder. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest
-   * ancestor's ID to fetch the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest ancestor's
+   * ID to fetch the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getFolderById.ts
+++ b/src/v2/parameters/getFolderById.ts
@@ -15,8 +15,8 @@ export const GetFolderByIdSchema = z.object({
   includeOperations: z.boolean().optional(),
   /**
    * Includes content properties associated with this folder in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
 });

--- a/src/v2/parameters/getFolderDescendants.ts
+++ b/src/v2/parameters/getFolderDescendants.ts
@@ -4,13 +4,13 @@ export const GetFolderDescendantsSchema = z.object({
   /** The ID of the folder. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch
-   * the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch the
+   * next set of results.
    */
   limit: z.number().optional(),
   /**
-   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the
-   * content type of the deepest descendant to fetch more descendants.
+   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the content
+   * type of the deepest descendant to fetch more descendants.
    */
   depth: z.number().optional(),
   /**

--- a/src/v2/parameters/getFooterCommentById.ts
+++ b/src/v2/parameters/getFooterCommentById.ts
@@ -21,21 +21,21 @@ export const GetFooterCommentByIdSchema = z.object({
    */
   includeProperties: z.boolean().optional(),
   /**
-   * Includes operations associated with this footer comment in the response, as defined in the `Operation` object.
-   * The number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property
-   * will be present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this footer comment in the response, as defined in the `Operation` object. The
+   * number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will
+   * be present to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes likes associated with this footer comment in the response. The number of results will be limited to 50
-   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
-   * are available and a link to retrieve the rest of the results.
+   * Includes likes associated with this footer comment in the response. The number of results will be limited to 50 and
+   * sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
+   * available and a link to retrieve the rest of the results.
    */
   includeLikes: z.boolean().optional(),
   /**
-   * Includes versions associated with this footer comment in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes versions associated with this footer comment in the response. The number of results will be limited to 50
+   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeVersions: z.boolean().optional(),
   /**

--- a/src/v2/parameters/getFooterCommentChildren.ts
+++ b/src/v2/parameters/getFooterCommentChildren.ts
@@ -18,8 +18,8 @@ export const GetFooterCommentChildrenSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getFooterCommentVersions.ts
+++ b/src/v2/parameters/getFooterCommentVersions.ts
@@ -6,8 +6,8 @@ export const GetFooterCommentVersionsSchema = z.object({
   /** The ID of the footer comment for which versions should be returned */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getFooterComments.ts
+++ b/src/v2/parameters/getFooterComments.ts
@@ -16,8 +16,8 @@ export const GetFooterCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getInlineCommentById.ts
+++ b/src/v2/parameters/getInlineCommentById.ts
@@ -21,21 +21,21 @@ export const GetInlineCommentByIdSchema = z.object({
    */
   includeProperties: z.boolean().optional(),
   /**
-   * Includes operations associated with this inline comment in the response, as defined in the `Operation` object.
-   * The number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property
-   * will be present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this inline comment in the response, as defined in the `Operation` object. The
+   * number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will
+   * be present to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes likes associated with this inline comment in the response. The number of results will be limited to 50
-   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
-   * are available and a link to retrieve the rest of the results.
+   * Includes likes associated with this inline comment in the response. The number of results will be limited to 50 and
+   * sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
+   * available and a link to retrieve the rest of the results.
    */
   includeLikes: z.boolean().optional(),
   /**
-   * Includes versions associated with this inline comment in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes versions associated with this inline comment in the response. The number of results will be limited to 50
+   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeVersions: z.boolean().optional(),
   /**

--- a/src/v2/parameters/getInlineCommentChildren.ts
+++ b/src/v2/parameters/getInlineCommentChildren.ts
@@ -18,8 +18,8 @@ export const GetInlineCommentChildrenSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getInlineCommentVersions.ts
+++ b/src/v2/parameters/getInlineCommentVersions.ts
@@ -6,8 +6,8 @@ export const GetInlineCommentVersionsSchema = z.object({
   /** The ID of the inline comment for which versions should be returned */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getInlineComments.ts
+++ b/src/v2/parameters/getInlineComments.ts
@@ -16,8 +16,8 @@ export const GetInlineCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getLabelBlogPosts.ts
+++ b/src/v2/parameters/getLabelBlogPosts.ts
@@ -8,8 +8,8 @@ export const GetLabelBlogPostsSchema = z.object({
   /** Filter the results based on space ids. Multiple space ids can be specified as a comma-separated list. */
   spaceId: z.array(z.number()).optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /** Used to sort the result by a particular field. */

--- a/src/v2/parameters/getLabelPages.ts
+++ b/src/v2/parameters/getLabelPages.ts
@@ -8,8 +8,8 @@ export const GetLabelPagesSchema = z.object({
   /** Filter the results based on space ids. Multiple space ids can be specified as a comma-separated list. */
   spaceId: z.array(z.number()).optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /** Used to sort the result by a particular field. */

--- a/src/v2/parameters/getLabels.ts
+++ b/src/v2/parameters/getLabels.ts
@@ -13,8 +13,8 @@ export const GetLabelsSchema = z.object({
   /** Used to sort the result by a particular field. */
   sort: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getPageAncestors.ts
+++ b/src/v2/parameters/getPageAncestors.ts
@@ -4,8 +4,8 @@ export const GetPageAncestorsSchema = z.object({
   /** The ID of the page. */
   id: z.number(),
   /**
-   * Maximum number of pages per result to return. If more results exist, call this endpoint with the highest
-   * ancestor's ID to fetch the next set of results.
+   * Maximum number of pages per result to return. If more results exist, call this endpoint with the highest ancestor's
+   * ID to fetch the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getPageById.ts
+++ b/src/v2/parameters/getPageById.ts
@@ -5,8 +5,8 @@ export const GetPageByIdSchema = z.object({
   /** The ID of the page to be returned. If you don't know the page ID, use Get pages and filter the results. */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSingleSchema.optional(),
   /** Retrieve the draft version of this page. */
@@ -20,32 +20,32 @@ export const GetPageByIdSchema = z.object({
   version: z.number().optional(),
   /**
    * Includes labels associated with this page in the response. The number of results will be limited to 50 and sorted
-   * in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
-   * available and a link to retrieve the rest of the results.
+   * in the default sort order. A `meta` and `_links` property will be present to indicate if more results are available
+   * and a link to retrieve the rest of the results.
    */
   includeLabels: z.boolean().optional(),
   /**
-   * Includes content properties associated with this page in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes content properties associated with this page in the response. The number of results will be limited to 50
+   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
   /**
-   * Includes operations associated with this page in the response, as defined in the `Operation` object. The number
-   * of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be
-   * present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this page in the response, as defined in the `Operation` object. The number of
+   * results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be present
+   * to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes likes associated with this page in the response. The number of results will be limited to 50 and sorted
-   * in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
-   * available and a link to retrieve the rest of the results.
+   * Includes likes associated with this page in the response. The number of results will be limited to 50 and sorted in
+   * the default sort order. A `meta` and `_links` property will be present to indicate if more results are available
+   * and a link to retrieve the rest of the results.
    */
   includeLikes: z.boolean().optional(),
   /**
-   * Includes versions associated with this page in the response. The number of results will be limited to 50 and
-   * sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
-   * available and a link to retrieve the rest of the results.
+   * Includes versions associated with this page in the response. The number of results will be limited to 50 and sorted
+   * in the default sort order. A `meta` and `_links` property will be present to indicate if more results are available
+   * and a link to retrieve the rest of the results.
    */
   includeVersions: z.boolean().optional(),
   /**

--- a/src/v2/parameters/getPageDescendants.ts
+++ b/src/v2/parameters/getPageDescendants.ts
@@ -4,13 +4,13 @@ export const GetPageDescendantsSchema = z.object({
   /** The ID of the page. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch
-   * the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch the
+   * next set of results.
    */
   limit: z.number().optional(),
   /**
-   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the
-   * content type of the deepest descendant to fetch more descendants.
+   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the content
+   * type of the deepest descendant to fetch more descendants.
    */
   depth: z.number().optional(),
   /**

--- a/src/v2/parameters/getPageFooterComments.ts
+++ b/src/v2/parameters/getPageFooterComments.ts
@@ -20,8 +20,8 @@ export const GetPageFooterCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of footer comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getPageInlineComments.ts
+++ b/src/v2/parameters/getPageInlineComments.ts
@@ -22,8 +22,8 @@ export const GetPageInlineCommentsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of inline comments per result to return. If more results exist, use the `Link` header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of inline comments per result to return. If more results exist, use the `Link` header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getPageLabels.ts
+++ b/src/v2/parameters/getPageLabels.ts
@@ -13,8 +13,8 @@ export const GetPageLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getPageVersions.ts
+++ b/src/v2/parameters/getPageVersions.ts
@@ -9,8 +9,8 @@ export const GetPageVersionsSchema = z.object({
    */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getPages.ts
+++ b/src/v2/parameters/getPages.ts
@@ -14,8 +14,8 @@ export const GetPagesSchema = z.object({
   /** Filter the results to pages based on their title. */
   title: z.string().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /** Filter the results to pages based on their subtype. */

--- a/src/v2/parameters/getPagesInSpace.ts
+++ b/src/v2/parameters/getPagesInSpace.ts
@@ -14,8 +14,8 @@ export const GetPagesInSpaceSchema = z.object({
   /** Filter the results to pages based on their title. */
   title: z.string().optional(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /**

--- a/src/v2/parameters/getSmartLinkAncestors.ts
+++ b/src/v2/parameters/getSmartLinkAncestors.ts
@@ -4,8 +4,8 @@ export const GetSmartLinkAncestorsSchema = z.object({
   /** The ID of the Smart Link in the content tree. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest
-   * ancestor's ID to fetch the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest ancestor's
+   * ID to fetch the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getSmartLinkById.ts
+++ b/src/v2/parameters/getSmartLinkById.ts
@@ -14,9 +14,9 @@ export const GetSmartLinkByIdSchema = z.object({
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes content properties associated with this Smart Link in the response. The number of results will be
-   * limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if
-   * more results are available and a link to retrieve the rest of the results.
+   * Includes content properties associated with this Smart Link in the response. The number of results will be limited
+   * to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
+   * results are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
 });

--- a/src/v2/parameters/getSmartLinkDescendants.ts
+++ b/src/v2/parameters/getSmartLinkDescendants.ts
@@ -4,13 +4,13 @@ export const GetSmartLinkDescendantsSchema = z.object({
   /** The ID of the smart link. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch
-   * the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch the
+   * next set of results.
    */
   limit: z.number().optional(),
   /**
-   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the
-   * content type of the deepest descendant to fetch more descendants.
+   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the content
+   * type of the deepest descendant to fetch more descendants.
    */
   depth: z.number().optional(),
   /**

--- a/src/v2/parameters/getSpaceById.ts
+++ b/src/v2/parameters/getSpaceById.ts
@@ -5,16 +5,16 @@ export const GetSpaceByIdSchema = z.object({
   /** The ID of the space to be returned. */
   id: z.number(),
   /**
-   * The content format type to be returned in the `description` field of the response. If available, the
-   * representation will be available under a response field of the same name under the `description` field.
+   * The content format type to be returned in the `description` field of the response. If available, the representation
+   * will be available under a response field of the same name under the `description` field.
    */
   descriptionFormat: SpaceDescriptionBodyRepresentationSchema.optional(),
   /** If the icon for the space should be fetched or not. */
   includeIcon: z.boolean().optional(),
   /**
-   * Includes operations associated with this space in the response, as defined in the `Operation` object. The number
-   * of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be
-   * present to indicate if more results are available and a link to retrieve the rest of the results.
+   * Includes operations associated with this space in the response, as defined in the `Operation` object. The number of
+   * results will be limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be present
+   * to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeOperations: z.boolean().optional(),
   /**
@@ -24,22 +24,21 @@ export const GetSpaceByIdSchema = z.object({
    */
   includeProperties: z.boolean().optional(),
   /**
-   * Includes space permissions associated with this space in the response. The number of results will be limited to
-   * 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
-   * results are available and a link to retrieve the rest of the results.
+   * Includes space permissions associated with this space in the response. The number of results will be limited to 50
+   * and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results
+   * are available and a link to retrieve the rest of the results.
    */
   includePermissions: z.boolean().optional(),
   /**
    * Includes role assignments associated with this space in the response. This parameter is only accepted for EAP
    * sites. The number of results will be limited to 50 and sorted in the default sort order. A `meta` and `_links`
-   * property will be present to indicate if more results are available and a link to retrieve the rest of the
-   * results.
+   * property will be present to indicate if more results are available and a link to retrieve the rest of the results.
    */
   includeRoleAssignments: z.boolean().optional(),
   /**
-   * Includes labels associated with this space in the response. The number of results will be limited to 50 and
-   * sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more results are
-   * available and a link to retrieve the rest of the results.
+   * Includes labels associated with this space in the response. The number of results will be limited to 50 and sorted
+   * in the default sort order. A `meta` and `_links` property will be present to indicate if more results are available
+   * and a link to retrieve the rest of the results.
    */
   includeLabels: z.boolean().optional(),
 });

--- a/src/v2/parameters/getSpaceContentLabels.ts
+++ b/src/v2/parameters/getSpaceContentLabels.ts
@@ -13,8 +13,8 @@ export const GetSpaceContentLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getSpaceLabels.ts
+++ b/src/v2/parameters/getSpaceLabels.ts
@@ -13,8 +13,8 @@ export const GetSpaceLabelsSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a
-   * relative URL that will return the next set of results.
+   * Maximum number of labels per result to return. If more results exist, use the `Link` header to retrieve a relative
+   * URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getSpaces.ts
+++ b/src/v2/parameters/getSpaces.ts
@@ -22,8 +22,8 @@ export const GetSpacesSchema = z.object({
   /** Used to sort the result by a particular field. */
   sort: SpaceSortOrderSchema.optional(),
   /**
-   * The content format type to be returned in the `description` field of the response. If available, the
-   * representation will be available under a response field of the same name under the `description` field.
+   * The content format type to be returned in the `description` field of the response. If available, the representation
+   * will be available under a response field of the same name under the `description` field.
    */
   descriptionFormat: SpaceDescriptionBodyRepresentationSchema.optional(),
   /** If the icon for the space should be fetched or not. */
@@ -34,8 +34,8 @@ export const GetSpacesSchema = z.object({
    */
   cursor: z.string().optional(),
   /**
-   * Maximum number of spaces per result to return. If more results exist, use the `Link` response header to retrieve
-   * a relative URL that will return the next set of results.
+   * Maximum number of spaces per result to return. If more results exist, use the `Link` response header to retrieve a
+   * relative URL that will return the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getTaskById.ts
+++ b/src/v2/parameters/getTaskById.ts
@@ -5,8 +5,8 @@ export const GetTaskByIdSchema = z.object({
   /** The ID of the task to be returned. If you don't know the task ID, use Get tasks and filter the results. */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
 });

--- a/src/v2/parameters/getTasks.ts
+++ b/src/v2/parameters/getTasks.ts
@@ -3,8 +3,8 @@ import { PrimaryBodyRepresentationSchema } from '../models';
 
 export const GetTasksSchema = z.object({
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   /** Specifies whether to include blank tasks in the response. Defaults to `true`. */
@@ -16,8 +16,8 @@ export const GetTasksSchema = z.object({
   /** Filters on the space ID of the task. Multiple IDs can be specified. */
   spaceId: z.array(z.number()).optional(),
   /**
-   * Filters on the page ID of the task. Multiple IDs can be specified. Note - page and blog post filters can be used
-   * in conjunction.
+   * Filters on the page ID of the task. Multiple IDs can be specified. Note - page and blog post filters can be used in
+   * conjunction.
    */
   pageId: z.array(z.number()).optional(),
   /**
@@ -36,10 +36,7 @@ export const GetTasksSchema = z.object({
    * milliseconds.
    */
   createdAtFrom: z.number().optional(),
-  /**
-   * Filters on end of date-time range of task based on creation date (inclusive). Input is epoch time in
-   * milliseconds.
-   */
+  /** Filters on end of date-time range of task based on creation date (inclusive). Input is epoch time in milliseconds. */
   createdAtTo: z.number().optional(),
   /** Filters on start of date-time range of task based on due date (inclusive). Input is epoch time in milliseconds. */
   dueAtFrom: z.number().optional(),

--- a/src/v2/parameters/getWhiteboardAncestors.ts
+++ b/src/v2/parameters/getWhiteboardAncestors.ts
@@ -4,8 +4,8 @@ export const GetWhiteboardAncestorsSchema = z.object({
   /** The ID of the whiteboard. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest
-   * ancestor's ID to fetch the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the highest ancestor's
+   * ID to fetch the next set of results.
    */
   limit: z.number().optional(),
 });

--- a/src/v2/parameters/getWhiteboardById.ts
+++ b/src/v2/parameters/getWhiteboardById.ts
@@ -14,9 +14,9 @@ export const GetWhiteboardByIdSchema = z.object({
    */
   includeOperations: z.boolean().optional(),
   /**
-   * Includes content properties associated with this whiteboard in the response. The number of results will be
-   * limited to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if
-   * more results are available and a link to retrieve the rest of the results.
+   * Includes content properties associated with this whiteboard in the response. The number of results will be limited
+   * to 50 and sorted in the default sort order. A `meta` and `_links` property will be present to indicate if more
+   * results are available and a link to retrieve the rest of the results.
    */
   includeProperties: z.boolean().optional(),
 });

--- a/src/v2/parameters/getWhiteboardDescendants.ts
+++ b/src/v2/parameters/getWhiteboardDescendants.ts
@@ -4,13 +4,13 @@ export const GetWhiteboardDescendantsSchema = z.object({
   /** The ID of the whiteboard. */
   id: z.number(),
   /**
-   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch
-   * the next set of results.
+   * Maximum number of items per result to return. If more results exist, call the endpoint with the cursor to fetch the
+   * next set of results.
    */
   limit: z.number().optional(),
   /**
-   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the
-   * content type of the deepest descendant to fetch more descendants.
+   * Maximum depth of descendants to return. If more results are required, use the endpoint corresponding to the content
+   * type of the deepest descendant to fetch more descendants.
    */
   depth: z.number().optional(),
   /**

--- a/src/v2/parameters/updateCustomContent.ts
+++ b/src/v2/parameters/updateCustomContent.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const UpdateCustomContentSchema = z.object({
   /**
-   * The ID of the custom content to be updated. If you don't know the custom content ID, use Get Custom Content by
-   * Type and filter the results.
+   * The ID of the custom content to be updated. If you don't know the custom content ID, use Get Custom Content by Type
+   * and filter the results.
    */
   id: z.number(),
   body: z.record(z.string(), z.any()).optional(),

--- a/src/v2/parameters/updateSpaceRole.ts
+++ b/src/v2/parameters/updateSpaceRole.ts
@@ -15,8 +15,8 @@ export const UpdateSpaceRoleSchema = z.object({
    */
   spacePermissions: z.array(z.string()),
   /**
-   * If space anonymous access is assigned to the role being modified, the Id of a role to migrate those assignments
-   * to can be specified. Anonymous access role assignments left unchanged if unspecified.
+   * If space anonymous access is assigned to the role being modified, the Id of a role to migrate those assignments to
+   * can be specified. Anonymous access role assignments left unchanged if unspecified.
    */
   anonymousReassignmentRoleId: z.string().optional(),
   /**

--- a/src/v2/parameters/updateTask.ts
+++ b/src/v2/parameters/updateTask.ts
@@ -5,8 +5,8 @@ export const UpdateTaskSchema = z.object({
   /** The ID of the task to be updated. If you don't know the task ID, use Get tasks and filter the results. */
   id: z.number(),
   /**
-   * The content format types to be returned in the `body` field of the response. If available, the representation
-   * will be available under a response field of the same name under the `body` field.
+   * The content format types to be returned in the `body` field of the response. If available, the representation will
+   * be available under a response field of the same name under the `body` field.
    */
   bodyFormat: PrimaryBodyRepresentationSchema.optional(),
   body: z.record(z.string(), z.any()).optional(),


### PR DESCRIPTION
Closes the red nightly schema audit and syncs the generated sources.

The audit failed on `GET /wiki/api/v2/spaces`: Confluence returns `currentActiveAlias: null` for a space with no alias, while the v2 spec declares a plain string. Strict response validation threw a `SchemaMismatchError`, taking down all twelve tests in `space.test.ts`. `getSpaceById` carried the same defect, latent only because the suite aborted before reaching it.

Both fixes are upstream in [apis-code-gen#7](https://github.com/MrRefactoring/apis-code-gen/pull/7); this syncs the regenerated output.

## Commits

**`style: reformat generated sources with the current formatter`** — 123 files, zero semantic change. Pre-existing debt, not churn from this sync: `pnpm run code:formatting` on a clean `master` checkout modifies these same files on its own. Kept separate so the fix below is readable.

**`fix: currentActiveAlias is nullable; type getRestrictionsByOperation`** — the substance, 6 files.

- `Space.currentActiveAlias` and `SpaceSummary.currentActiveAlias` are now `string | null | undefined`. Additive for consumers: the field was already optional, so any narrowing that handled `undefined` handles `null`.
- `getRestrictionsByOperation` no longer returns `Promise<unknown>`. It resolves to a `GetRestrictionsByOperation` and is validated like every other endpoint. The spec describes this one incorrectly — a map of `operationType`/`_links` envelopes that do not exist — so the model was corrected upstream to what the endpoint answers: the restriction directly under `read` / `update`, beside a top-level `_links`. Typing it from the spec as published would have traded one red audit for another, nine drift entries' worth.

## Release

Two changesets: `patch` for the nullable fix, `minor` for the newly typed endpoint.

## Verification

Full live audit against a real Confluence site: **56/56 files, 493/493 tests, zero drift.** The twelve previously skipped `space.test.ts` tests now run. `build`, `check:attw`, `check:consumers`, lint and 168 unit tests all pass.